### PR TITLE
Framework, scripts and tests.

### DIFF
--- a/.bitcoin-maintainer-tools.json
+++ b/.bitcoin-maintainer-tools.json
@@ -1,0 +1,27 @@
+{
+   "description" : "This json object describes the local details of the repository to guide how the tools operate.",
+   "subtrees" : {
+      "description" : "Subtrees of the repository which should be ignored since they follow different rules. Expressed as a list of fmnmatch expressions.",
+      "fnmatches" : [
+      ]
+   },
+   "no_copyright_header_expected" : {
+      "description" : "Source files where it is acceptable to not have a MIT Licence copyright header. Expressed as a list of fnmatch expressions.",
+      "fnmatches" : [
+         "*__init__.py",
+         "build-for-compare.py",
+         "clang-format.py"
+      ]
+   },
+   "other_copyright_occurrences_expected" : {
+      "description" : "Files where it is expected to have an occurrence of the sequence of characters 'Copyright', 'COPYRIGHT', or 'copyright' in the file outside of the MIT Licence copyright header. This list helps to ensures we are keeping close track where there may be external considerations for licence and copyright. Expressed as a list of fnmatch expressions.",
+      "fnmatches" : [
+         "bin/checks.py",
+         "bin/reports.py",
+         "bin/copyright_header.py",
+         "test/test_all.py",
+         "test/test_copyright_header.py",
+         "clang-format.py"
+      ]
+   }
+}

--- a/.fallback-bitcoin-maintainer-tools.json
+++ b/.fallback-bitcoin-maintainer-tools.json
@@ -1,0 +1,82 @@
+{
+   "description" : "This json object is the failback for when the .bitcoin-maintainer-tools.json file is not present in the target repository. It describes the details of the repository to guide how the tools operate.",
+   "subtrees" : {
+      "description" : "Subtrees of the repository which should be ignored since they follow different rules. Expressed as a list of fmnmatch expressions.",
+      "fnmatches" : [
+         "src/secp256k1/*",
+         "src/leveldb/*",
+         "src/univalue/*",
+         "src/crypto/ctaes/*"
+      ]
+   },
+   "clang_format_style" : {
+      "description" : "File in the repository which contains the clang-format style definition.",
+      "value" : "src/.clang-format"
+   },
+   "no_copyright_header_expected" : {
+      "description" : "Source files where it is acceptable to not have a MIT Licence copyright header. Expressed as a list of fnmatch expressions.",
+      "fnmatches" : [
+         "*__init__.py",
+         "doc/man/Makefile.am",
+         "build-aux/m4/ax_boost_base.m4",
+         "build-aux/m4/ax_boost_chrono.m4",
+         "build-aux/m4/ax_boost_filesystem.m4",
+         "build-aux/m4/ax_boost_program_options.m4",
+         "build-aux/m4/ax_boost_system.m4",
+         "build-aux/m4/ax_boost_thread.m4",
+         "build-aux/m4/ax_boost_unit_test_framework.m4",
+         "build-aux/m4/ax_check_compile_flag.m4",
+         "build-aux/m4/ax_check_link_flag.m4",
+         "build-aux/m4/ax_check_preproc_flag.m4",
+         "build-aux/m4/ax_cxx_compile_stdcxx.m4",
+         "build-aux/m4/ax_gcc_func_attribute.m4",
+         "build-aux/m4/ax_pthread.m4",
+         "build-aux/m4/l_atomic.m4",
+         "src/qt/bitcoinstrings.cpp",
+         "src/chainparamsseeds.h",
+         "src/tinyformat.h",
+         "qa/rpc-tests/test_framework/bignum.py",
+         "contrib/devtools/clang-format-diff.py",
+         "qa/rpc-tests/test_framework/authproxy.py",
+         "qa/rpc-tests/test_framework/key.py"
+      ]
+   },
+   "clang_format_recommended" : {
+      "description" : "The recommendation for the minimum version of clang-format to be used for applying formatting. Different versions have small discrepancies for applied formatting and the tools will warn if an old version is being used.",
+      "min_version" : "3.9.0"
+   },
+   "other_copyright_occurrences_expected" : {
+      "description" : "Files where it is expected to have an occurrence of the sequence of characters 'Copyright', 'COPYRIGHT', or 'copyright' in the file outside of the MIT Licence copyright header. This list helps to ensures we are keeping close track where there may be external considerations for licence and copyright. Expressed as a list of fnmatch expressions.",
+      "fnmatches" : [
+         "contrib/devtools/copyright_header.py",
+         "contrib/devtools/gen-manpages.sh",
+         "share/qt/extract_strings_qt.py",
+         "src/Makefile.qt.include",
+         "src/clientversion.h",
+         "src/init.cpp",
+         "src/qt/bitcoinstrings.cpp",
+         "src/qt/splashscreen.cpp",
+         "src/util.cpp",
+         "src/util.h",
+         "src/tinyformat.h",
+         "contrib/devtools/clang-format-diff.py",
+         "qa/rpc-tests/test_framework/authproxy.py",
+         "qa/rpc-tests/test_framework/key.py",
+         "contrib/devtools/git-subtree-check.sh",
+         "build-aux/m4/l_atomic.m4",
+         "build-aux/m4/ax_boost_base.m4",
+         "build-aux/m4/ax_boost_chrono.m4",
+         "build-aux/m4/ax_boost_filesystem.m4",
+         "build-aux/m4/ax_boost_program_options.m4",
+         "build-aux/m4/ax_boost_system.m4",
+         "build-aux/m4/ax_boost_thread.m4",
+         "build-aux/m4/ax_boost_unit_test_framework.m4",
+         "build-aux/m4/ax_check_compile_flag.m4",
+         "build-aux/m4/ax_check_link_flag.m4",
+         "build-aux/m4/ax_check_preproc_flag.m4",
+         "build-aux/m4/ax_cxx_compile_stdcxx.m4",
+         "build-aux/m4/ax_gcc_func_attribute.m4",
+         "build-aux/m4/ax_pthread.m4"
+      ]
+   }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - TEST_SCRIPT="test/test_basic_style.py"
     - TEST_SCRIPT="test/test_clang_format.py"
     - TEST_SCRIPT="test/test_copyright_header.py"
+    - TEST_SCRIPT="bin/basic_style.py check bin/ framework/ test/"
+    - TEST_SCRIPT="bin/copyright_header.py check"
 install:
     - travis_retry sudo apt-get install libboost-all-dev libevent-dev libprotobuf-dev clang-3.8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+dist: trusty
+os: linux
+language: generic
+python:
+  - "3.6"
+cache:
+  directories:
+  - /tmp/bitcoin-maintainer-tools/clang-release-dl/
+  - /tmp/bitcoin-maintainer-tools/berkeley-db/
+env:
+  matrix:
+    - TEST_SCRIPT="test/test_clone_configure_build.py"
+    - TEST_SCRIPT="test/test_clang_static_analysis.py"
+    - TEST_SCRIPT="test/test_reports.py"
+    - TEST_SCRIPT="test/test_checks.py"
+    - TEST_SCRIPT="test/test_basic_style.py"
+    - TEST_SCRIPT="test/test_clang_format.py"
+    - TEST_SCRIPT="test/test_copyright_header.py"
+install:
+    - travis_retry sudo apt-get install libboost-all-dev libevent-dev libprotobuf-dev clang-3.8
+script:
+    - travis_wait 60 $TEST_SCRIPT

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,91 @@
+Contents
+========
+This directory contains executable scripts for bitcoin developers and maintainers.
+
+All scripts have a `-h` option which gives a detailed description of usage and options.
+
+The scripts may write to `/tmp/bitcoin-maintainer-tools/` to hold state when needed.
+
+Operations that generate information have a `--json` option to assist programmatic uses of the data.
+
+clone\_configure\_build.py
+==========================
+Clones, configures builds a bitcoin repository to a given directory from scratch. This includes downloading and building BerkelyDB 4.8. It assumes the local environment has the rest of the dependency packages installed.
+
+The upstream url and branch can be given as options.
+
+It follows the most straightforward configuration path as described by `doc/build_unix.md` in `https://github.com/bitcoin/bitcoin`. If a non-default configuration is required, manual configuration is the best option.
+
+clang\_format.py
+================
+
+Provides a set of subcommands for using the `clang-format` tool to operate on on source files.
+
+clang\_format.py report
+-----------------------
+Generates a report with format metrics on the target repository or target files.
+
+clang\_format.py check
+-----------------------
+Validates that the target repository or target files match a particular format.
+
+clang\_format.py format
+-----------------------
+Applies formatting to a target repository or target files.
+
+basic\_style.py
+===============
+Provides a set of subcommands that does some basic source file coding style checking and reporting. The style rules are defined inside the script as regex expressions.
+
+basic\_style.py report
+----------------------
+Generates a report with metrics on the target repository or target files.
+
+basic\_style.py check
+---------------------
+Validates that the target repository or target files match the style rules.
+
+basic\_style.py fix
+-------------------
+Performs basic regex search-and-replace to fix the style issues that are found in the repo or in target files.
+
+clang\_static\_analysis.py
+==========================
+Provides a set of subcommmands for running `scan-build` on the repository and revealing any issues.
+
+clang\_static\_analysis.py report
+---------------------------------
+Runs `scan-build` and generates a summary report of the results.
+
+clang\_static\_analysis.py check
+---------------------------------
+Runs `scan-build` and validates that there are no issues found. If there are issues found, details are displayed.
+
+copyright\_header.py
+====================
+Provides a set of subcommands that analyze and assist managing the set of copyright headers of source files of the repository.
+
+copyright\_header.py report
+---------------------------
+Generates a report with copyright header metrics of the target repository or target files.
+
+copyright\_header.py check
+--------------------------
+Validates that the copyright headers of the target repository or target files are in an expected state.
+
+copyright\_header.py update
+---------------------------
+Adjusts the end year of the copyright headers of the target repository or target files to make it match the year of the last edit, as determined by the `git log` output.
+
+copyright\_header.py insert
+---------------------------
+Inserts a properly-formatted `The Bitcoin Core developers`-held MIT License copyright header in target files where it is currently missing.
+
+reports.py
+==========
+Runs the suite of `report` subcommands provided by other scripts in this directory upon a target.
+
+checks.py
+=========
+Runs the suite of `check` subcommands provided by other scripts in this directory upon a target.
+

--- a/bin/basic_style.py
+++ b/bin/basic_style.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import re
+import sys
+import itertools
+import argparse
+import json
+
+from framework.print.buffer import PrintBuffer
+from framework.file.filter import FileFilter
+from framework.file.info import FileInfo
+from framework.file.style import FileStyleDiff, FileStyleScore
+from framework.cmd.file_content import FileContentCmd
+from framework.argparse.option import add_jobs_option
+from framework.argparse.option import add_json_option
+from framework.git.parameter import add_git_tracked_targets_parameter
+
+###############################################################################
+# style rules
+###############################################################################
+
+STYLE_RULES = [
+    {'title':   'No tabstops',
+     'applies': ['*.c', '*.cpp', '*.h', '*.py', '*.sh'],
+     'regex':   '\t',
+     'fix':     '    '},
+    {'title':   'No trailing whitespace on a line',
+     'applies': ['*.c', '*.cpp', '*.h', '*.py', '*.sh'],
+     'regex':   ' \n',
+     'fix':     '\n'},
+    {'title':   'No more than three consecutive newlines',
+     'applies': ['*.c', '*.cpp', '*.h', '*.py', '*.sh'],
+     'regex':   '\n\n\n\n',
+     'fix':     '\n\n\n'},
+    {'title':   'Do not end a line with a semicolon',
+     'applies': ['*.py'],
+     'regex':   ';\n',
+     'fix':     '\n'},
+    {'title':   'Do not end a line with two semicolons',
+     'applies': ['*.c', '*.cpp', '*.h'],
+     'regex':   ';;\n',
+     'fix':     ';\n'},
+]
+
+APPLIES_TO = list(set(itertools.chain(*[r['applies'] for r in STYLE_RULES])))
+
+
+class BasicStyleRules(object):
+    """
+    Wrapping of the rules with helpers.
+    """
+    def __init__(self, repository):
+        self.repository = repository
+        self.rules = STYLE_RULES
+        for rule in self:
+            rule['regex_compiled'] = re.compile(rule['regex'])
+            rule['filter'] = FileFilter()
+            rule['filter'].append_include(rule['applies'],
+                                          base_path=str(self.repository))
+
+    def __iter__(self):
+        return (rule for rule in self.rules)
+
+    def rules_that_apply(self, file_path):
+        return (rule for rule in self.rules if
+                rule['filter'].evaluate(file_path))
+
+    def rule_with_title(self, title):
+        return next((rule for rule in self.rules if rule['title'] == title),
+                    None)
+
+
+###############################################################################
+# file info
+###############################################################################
+
+class BasicStyleFileInfo(FileInfo):
+    """
+    Obtains and represents the information regarding a single file.
+    """
+    def __init__(self, repository, file_path, rules):
+        super().__init__(repository, file_path)
+        self.rules = rules
+        self['rules_that_apply'] = list(self.rules.rules_that_apply(file_path))
+
+    def _find_line_of_match(self, match):
+        contents_before_match = self['content'][:match.start()]
+        contents_after_match = self['content'][match.end() - 1:]
+        line_start_char = contents_before_match.rfind('\n') + 1
+        line_end_char = match.end() + contents_after_match.find('\n')
+        return {'context':   self['content'][line_start_char:line_end_char],
+                'number':    contents_before_match.count('\n') + 1,
+                'character': match.start() - line_start_char + 1}
+
+    def _find_issues(self, content):
+        for rule in self['rules_that_apply']:
+            matches = [match for match in
+                       rule['regex_compiled'].finditer(content) if
+                       match is not None]
+            lines = [self._find_line_of_match(match) for match in matches]
+            for line in lines:
+                yield {'file_path':  self['file_path'],
+                       'rule_title': rule['title'],
+                       'line':       line}
+
+    def _apply_fix(self, content, rule_title):
+        # Multiple instances of a particular issue could be present. For
+        # example, multiple spaces at the end of a line. So, we repeat the
+        # search-and-replace until search matches are exhausted.
+        fixed_content = content
+        while True:
+            rule = self.rules.rule_with_title(rule_title)
+            fixed_content, subs = rule['regex_compiled'].subn(rule['fix'],
+                                                              fixed_content)
+            if subs == 0:
+                break
+        return fixed_content
+
+    def _fix_content(self):
+        fixed_content = self['content']
+        issues = self['issues']
+        # Multiple types of issues could be overlapping. For example, a tabstop
+        # at the end of a line so the fix then creates whitespace at the end.
+        # We repeat fix-up cycles until everything is cleared.
+        while len(issues) > 0:
+            fixed_content = self._apply_fix(fixed_content,
+                                            issues[0]['rule_title'])
+            issues = list(self._find_issues(fixed_content))
+        return fixed_content
+
+    def compute(self):
+        self['issues'] = list(self._find_issues(self['content']))
+        self['fixed_content'] = self._fix_content()
+        self.set_write_content(self['fixed_content'])
+        self.update(FileStyleDiff(self['content'], self['fixed_content']))
+        self['matching'] = self['content'] == self['fixed_content']
+
+
+###############################################################################
+# cmd base class
+###############################################################################
+
+class BasicStyleCmd(FileContentCmd):
+    """
+    Common base class for the commands in this script.
+    """
+    def __init__(self, settings):
+        settings.include_fnmatches = APPLIES_TO
+        super().__init__(settings)
+        self.rules = BasicStyleRules(self.repository)
+
+    def _file_info_list(self):
+        return [BasicStyleFileInfo(self.repository, f, self.rules) for f in
+                self.files_targeted]
+
+
+###############################################################################
+# report cmd
+###############################################################################
+
+class ReportCmd(BasicStyleCmd):
+    """
+    'report' subcommand class.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "Basic Style Report"
+
+    def _exec(self):
+        r = super()._exec()
+        file_infos = self.file_infos
+        r['jobs'] = self.jobs
+        r['elapsed_time'] = self.elapsed_time
+        r['lines_before'] = sum(f['lines_before'] for f in file_infos)
+        r['lines_added'] = sum(f['lines_added'] for f in file_infos)
+        r['lines_removed'] = sum(f['lines_removed'] for f in file_infos)
+        r['lines_unchanged'] = sum(f['lines_unchanged'] for f in file_infos)
+        r['lines_after'] = sum(f['lines_after'] for f in file_infos)
+        score = FileStyleScore(r['lines_before'], r['lines_added'],
+                               r['lines_removed'], r['lines_unchanged'],
+                               r['lines_after'])
+        r['style_score'] = float(score)
+        r['matching'] = sum(1 for f in file_infos if f['matching'])
+        r['not_matching'] = sum(1 for f in file_infos if not f['matching'])
+
+        all_issues = list(itertools.chain.from_iterable(
+            file_info['issues'] for file_info in file_infos))
+
+        r['rule_evaluation'] = {}
+        for rule in self.rules:
+            examined = sum(1 for f in file_infos if
+                           rule['filter'].evaluate(f['file_path']))
+            occurrence_count = len([f for f in all_issues if
+                                    f['rule_title'] == rule['title']])
+            file_count = len(set([f['file_path'] for f in all_issues if
+                                  f['rule_title'] == rule['title']]))
+            r['rule_evaluation'][rule['title']] = (
+                {'extensions': rule['applies'], 'examined': examined,
+                 'files': file_count, 'occurrences': occurrence_count})
+        return r
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        b.add(super()._output(results))
+        r = results
+        b.add("%-32s %8.02fs\n" % ("Elapsed time:", r['elapsed_time']))
+        b.separator()
+        for title, evaluation in sorted(r['rule_evaluation'].items()):
+            b.add('"%s":\n' % title)
+            b.add('  %-30s %s\n' % ("Applies to:", evaluation['extensions']))
+            b.add('  %-30s %8d\n' % ("Files examined:",
+                                     evaluation['examined']))
+            b.add('  %-30s %8d\n' % ("Occurrences of issue:",
+                                     evaluation['occurrences']))
+            b.add('  %-30s %8d\n\n' % ("Files with issue:",
+                                       evaluation['files']))
+        b.separator()
+        b.add("%-32s %8d\n" % ("Files scoring 100%", r['matching']))
+        b.add("%-32s %8d\n" % ("Files scoring <100%", r['not_matching']))
+        b.separator()
+        b.add("Overall scoring:\n\n")
+        score = FileStyleScore(r['lines_before'], r['lines_added'],
+                               r['lines_removed'], r['lines_unchanged'],
+                               r['lines_after'])
+        b.add(str(score))
+        b.separator()
+        return str(b)
+
+
+def add_report_cmd(subparsers):
+    report_help = ("Validates that the selected targets do not have basic "
+                   "style issues, give a per-file report and returns a "
+                   "non-zero shell status if there are any basic style issues "
+                   "discovered.")
+    parser = subparsers.add_parser('report', help=report_help)
+    parser.set_defaults(cmd=lambda o: ReportCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# check cmd
+###############################################################################
+
+class CheckCmd(BasicStyleCmd):
+    """
+    'check' subcommand class.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "Basic Style Check"
+
+    def _exec(self):
+        r = super()._exec()
+        file_infos = self.file_infos
+        r['issues'] = list(
+            itertools.chain.from_iterable(f['issues'] for f in file_infos))
+        return r
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        b.add(super()._output(results))
+        r = results
+        for issue in r['issues']:
+            b.separator()
+            b.add("An issue was found with ")
+            b.add_red("%s\n" % issue['file_path'])
+            b.add('Rule: "%s"\n\n' % issue['rule_title'])
+            b.add('line %d:\n' % issue['line']['number'])
+            b.add("%s" % issue['line']['context'])
+            b.add(' ' * (issue['line']['character'] - 1))
+            b.add_red("^\n")
+        b.separator()
+        if len(r['issues']) == 0:
+            b.add_green("No style issues found!\n")
+        else:
+            b.add_red("These issues can be fixed automatically by running:\n")
+            b.add("$ basic_style.py fix [target [target ...]]\n")
+        b.separator()
+        return str(b)
+
+    def _shell_exit(self, results):
+        return (0 if len(results['issues']) == 0 else "*** style issue found")
+
+
+def add_check_cmd(subparsers):
+    check_help = ("Validates that the selected targets do not have basic "
+                  "style issues, give a per-file report and returns a "
+                  "non-zero shell status if there are any basic style issues "
+                  "discovered.")
+    parser = subparsers.add_parser('check', help=check_help)
+    parser.set_defaults(cmd=lambda o: CheckCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# fix cmd
+###############################################################################
+
+class FixCmd(BasicStyleCmd):
+    """
+    'fix' subcommand class.
+    """
+    def __init__(self, settings):
+        settings.json = False
+        super().__init__(settings)
+        self.title = "Basic Style Fix"
+
+    def _exec(self):
+        super()._exec()
+        self.file_infos.write_all()
+
+    def _output(self, results):
+        return None
+
+
+def add_fix_cmd(subparsers):
+    fix_help = ("Applies basic style fixes to the target files.")
+    parser = subparsers.add_parser('fix', help=fix_help)
+    parser.set_defaults(cmd=lambda o: FixCmd(o))
+    add_jobs_option(parser)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+
+if __name__ == "__main__":
+    description = ("A utility for checking some basic style regexes against "
+                   "the contents of source files in the repository. It "
+                   "produces reports of style metrics and also can fix issues"
+                   "with simple search-and-replace logic.")
+    parser = argparse.ArgumentParser(description=description)
+    subparsers = parser.add_subparsers()
+    add_report_cmd(subparsers)
+    add_check_cmd(subparsers)
+    add_fix_cmd(subparsers)
+    settings = parser.parse_args()
+    if not hasattr(settings, "cmd"):
+        parser.print_help()
+        sys.exit("*** missing argument")
+    settings.cmd(settings).run()

--- a/bin/checks.py
+++ b/bin/checks.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import argparse
+
+from framework.cmd.repository import RepositoryCmds
+from clang_static_analysis import CheckCmd as ClangStaticAnalysisCheck
+from basic_style import CheckCmd as BasicStyleCheck
+from copyright_header import CheckCmd as CopyrightHeaderCheck
+from clang_format import CheckCmd as ClangFormatCheck
+from framework.argparse.option import add_jobs_option
+from framework.argparse.option import add_json_option
+from framework.clang.option import add_clang_options
+from framework.clang.option import finish_clang_settings
+from framework.git.parameter import add_git_tracked_targets_parameter
+
+
+class Checks(RepositoryCmds):
+    """
+    Invokes several underlying RepositoryCmd check command instances and and
+    aggregates the results.
+    """
+    def __init__(self, settings):
+        repository_cmds = {
+            'copyright_header':      CopyrightHeaderCheck(settings),
+            'basic_style':           BasicStyleCheck(settings),
+            'clang_format':          ClangFormatCheck(settings),
+            'clang_static_analysis': ClangStaticAnalysisCheck(settings),
+        }
+        self.json = settings.json
+        super().__init__(settings, repository_cmds, silent=settings.json)
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        reports = [(self.repository_cmds[l].title + ":\n" +
+                    self.repository_cmds[l]._output(r)) for l, r in
+                   sorted(results.items())]
+        return '\n'.join(reports)
+
+
+if __name__ == "__main__":
+    description = ("Wrapper to invoke a collection of scripts that check on "
+                   "the state of the repository.")
+    parser = argparse.ArgumentParser(description=description)
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_clang_options(parser, report_path=True, style_file=True, force=True)
+    add_git_tracked_targets_parameter(parser)
+    settings = parser.parse_args()
+    finish_clang_settings(settings)
+    checks = Checks(settings)
+    checks.run()

--- a/bin/clang_format.py
+++ b/bin/clang_format.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import argparse
+import hashlib
+import json
+
+from framework.print.buffer import PrintBuffer
+from framework.argparse.option import add_jobs_option
+from framework.argparse.option import add_json_option
+from framework.file.info import FileInfo
+from framework.file.style import FileStyleDiff, FileStyleScore
+from framework.cmd.file_content import FileContentCmd
+from framework.git.parameter import add_git_tracked_targets_parameter
+from framework.clang.option import add_clang_options
+from framework.clang.option import finish_clang_settings
+
+
+APPLIES_TO = ['*.cpp', '*.h']
+
+
+###############################################################################
+# gather file and diff info
+###############################################################################
+
+class ClangFormatFileInfo(FileInfo):
+    """
+    Obtains and represents the information regarding a single file obtained
+    from clang-format.
+    """
+    def __init__(self, repository, file_path, clang_format, force):
+        super().__init__(repository, file_path)
+        self.clang_format = clang_format
+        self.force = force
+
+    def read(self):
+        super().read()
+        self['formatted'] = (
+            self.clang_format.read_formatted_file(self['file_path']))
+        self._exit_if_parameters_unsupported()
+        self.set_write_content(self['formatted'])
+
+    def _exit_if_parameters_unsupported(self):
+        if self.force:
+            return
+        rejected_parameters = self.clang_format.style.rejected_parameters
+        if len(rejected_parameters) > 0:
+            b = PrintBuffer()
+            b.add_red("\nERROR: ")
+            b.add("clang-format version %s does not support all parameters "
+                  "given in\n%s\n\n" % (self.clang_format.binary_version,
+                                        self.clang_format.style))
+            b.add("Unsupported parameters:\n")
+            for parameter in rejected_parameters:
+                b.add("\t%s\n" % parameter)
+            # The applied formating has subtle differences that vary between
+            # major releases of clang-format. The recommendation should
+            # probably follow the latest widely-available stable release.
+            repo_info = self['repository'].repo_info
+            b.add("\nUsing clang-format version %s or higher is recommended\n"
+                  % repo_info['clang_format_recommended']['min_version'])
+            b.add("Use the --force option to override and proceed anyway.\n\n")
+            b.flush()
+            sys.exit("*** missing clang-format support.")
+
+    def compute(self):
+        self['matching'] = self['content'] == self['formatted']
+        self['formatted_md5'] = (
+            hashlib.md5(self['formatted'].encode('utf-8')).hexdigest())
+        self.update(FileStyleDiff(self['content'], self['formatted']))
+
+
+###############################################################################
+# cmd base class
+###############################################################################
+
+class ClangFormatCmd(FileContentCmd):
+    """
+    Common base class for the commands in this script.
+    """
+    def __init__(self, settings):
+        assert hasattr(settings, 'force')
+        assert hasattr(settings, 'clang_format')
+        settings.include_fnmatches = APPLIES_TO
+        super().__init__(settings)
+        self.force = settings.force
+        self.clang_format = settings.clang_format
+
+    def _file_info_list(self):
+        return [ClangFormatFileInfo(self.repository, f, self.clang_format,
+                                    self.force)
+                for f in self.files_targeted]
+
+
+###############################################################################
+# report cmd
+###############################################################################
+
+class ReportCmd(ClangFormatCmd):
+    """
+    'report' subcommand class.
+    """
+    def __init__(self, settings):
+        settings.force = True
+        super().__init__(settings)
+        self.title = "Clang Format Report"
+
+    def _cumulative_md5(self):
+        # nothing fancy, just hash all the hashes
+        h = hashlib.md5()
+        for f in self.file_infos:
+            h.update(f['formatted_md5'].encode('utf-8'))
+        return h.hexdigest()
+
+    def _files_in_ranges(self):
+        files_in_ranges = {}
+        ranges = [(90, 99), (80, 89), (70, 79), (60, 69), (50, 59), (40, 49),
+                  (30, 39), (20, 29), (10, 19), (0, 9)]
+        for lower, upper in ranges:
+            files_in_ranges['%2d%%-%2d%%' % (lower, upper)] = (
+                sum(1 for f in self.file_infos if
+                    f['score'].in_range(lower, upper)))
+        return files_in_ranges
+
+    def _exec(self):
+        r = super()._exec()
+        file_infos = self.file_infos
+        r['clang_format_path'] = self.clang_format.binary_path
+        r['clang_format_version'] = str(self.clang_format.binary_version)
+        r['clang_style_path'] = str(self.clang_format.style_path)
+        r['rejected_parameters'] = self.clang_format.style.rejected_parameters
+        r['elapsed_time'] = self.elapsed_time
+        r['lines_before'] = sum(f['lines_before'] for f in file_infos)
+        r['lines_added'] = sum(f['lines_added'] for f in file_infos)
+        r['lines_removed'] = sum(f['lines_removed'] for f in file_infos)
+        r['lines_unchanged'] = sum(f['lines_unchanged'] for f in file_infos)
+        r['lines_after'] = sum(f['lines_after'] for f in file_infos)
+        score = FileStyleScore(r['lines_before'], r['lines_added'],
+                               r['lines_removed'], r['lines_unchanged'],
+                               r['lines_after'])
+        r['style_score'] = float(score)
+        r['slow_diffs'] = [{'file_path': f['file_path'],
+                            'diff_time': f['diff_time']} for f in
+                           file_infos if f['diff_time'] > 1.0]
+        r['matching'] = sum(1 for f in file_infos if f['matching'])
+        r['not_matching'] = sum(1 for f in file_infos if not f['matching'])
+        r['formatted_md5'] = self._cumulative_md5()
+        r['files_in_ranges'] = self._files_in_ranges()
+        return r
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        b.add(super()._output(results))
+        r = results
+        b.add("%-30s %s\n" % ("clang-format bin:", r['clang_format_path']))
+        b.add("%-30s %s\n" % ("clang-format version:",
+                              r['clang_format_version']))
+        b.add("%-30s %s\n" % ("Using style in:", r['clang_style_path']))
+        b.separator()
+        if len(r['rejected_parameters']) > 0:
+            b.add_red("WARNING")
+            b.add(" - This version of clang-format does not support the "
+                  "following style\nparameters, so they were not used:\n\n")
+            for param in r['rejected_parameters']:
+                b.add("%s\n" % param)
+            b.separator()
+        b.add("%-30s %.02fs\n" % ("Elapsed time:", r['elapsed_time']))
+        if len(r['slow_diffs']) > 0:
+            b.add("Slowest diffs:\n")
+            for slow in r['slow_diffs']:
+                b.add("%6.02fs for %s\n" % (slow['diff_time'],
+                                            slow['file_path']))
+        b.separator()
+        b.add("%-30s %4d\n" % ("Files scoring 100%:", r['matching']))
+        b.add("%-30s %4d\n" % ("Files scoring <100%:", r['not_matching']))
+        b.add("%-30s %s\n" % ("Formatted Content MD5:", r['formatted_md5']))
+        b.separator()
+        for score_range in reversed(sorted(r['files_in_ranges'].keys())):
+            b.add("%-30s %4d\n" % ("Files scoring %s:" % score_range,
+                                   r['files_in_ranges'][score_range]))
+        b.separator()
+        b.add("Overall scoring:\n\n")
+        score = FileStyleScore(r['lines_before'], r['lines_added'],
+                               r['lines_removed'], r['lines_unchanged'],
+                               r['lines_after'])
+        b.add(str(score))
+        b.separator()
+        return str(b)
+
+
+def add_report_cmd(subparsers):
+    report_help = ("Produces a report with the analysis of the code format "
+                   "adherence of the selected targets taken as a group.")
+    parser = subparsers.add_parser('report', help=report_help)
+    parser.set_defaults(cmd=lambda o: ReportCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_clang_options(parser, style_file=True)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# check cmd
+###############################################################################
+
+class CheckCmd(ClangFormatCmd):
+    """
+    'check' subcommand class.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "Clang Format Check"
+
+    def _exec(self):
+        r = super()._exec()
+        r['failures'] = [{'file_path':       f['file_path'],
+                          'style_score':     float(f['score']),
+                          'lines_before':    f['lines_before'],
+                          'lines_added':     f['lines_added'],
+                          'lines_removed':   f['lines_removed'],
+                          'lines_unchanged': f['lines_unchanged'],
+                          'lines_after':     f['lines_after']}
+                         for f in self.file_infos if not f['matching']]
+        return r
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        b.add(super()._output(results))
+        r = results
+        for f in r['failures']:
+            b.add("A code format issue was detected in ")
+            b.add_red("%s\n\n" % f['file_path'])
+            score = FileStyleScore(f['lines_before'], f['lines_added'],
+                                   f['lines_removed'], f['lines_unchanged'],
+                                   f['lines_after'])
+            b.add(str(score))
+            b.separator()
+        if len(r['failures']) == 0:
+            b.add_green("No format issues found!\n")
+        else:
+            b.add_red("These files can be formatted by running:\n")
+            b.add("$ clang_format.py format [option [option ...]] "
+                  "[target [target ...]]\n")
+        b.separator()
+        return str(b)
+
+    def _shell_exit(self, results):
+        return (0 if len(results['failures']) == 0 else
+                "*** code format issue found")
+
+
+def add_check_cmd(subparsers):
+    check_help = ("Validates that the selected targets match the style, gives "
+                  "a per-file report and returns a non-zero shell status if "
+                  "there are any format issues discovered.")
+    parser = subparsers.add_parser('check', help=check_help)
+    parser.set_defaults(cmd=lambda o: CheckCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_clang_options(parser, style_file=True, force=True)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# format cmd
+###############################################################################
+
+class FormatCmd(ClangFormatCmd):
+    """
+    'format' subcommand class.
+    """
+    def __init__(self, settings):
+        settings.json = False
+        super().__init__(settings)
+        self.title = "Clang Format"
+
+    def _exec(self):
+        super()._exec()
+        self.file_infos.write_all()
+
+    def _output(self, results):
+        return None
+
+
+def add_format_cmd(subparsers):
+    format_help = ("Applies the style formatting to the target files.")
+    parser = subparsers.add_parser('format', help=format_help)
+    parser.set_defaults(cmd=lambda o: FormatCmd(o))
+    add_clang_options(parser, style_file=True, force=True)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+
+if __name__ == "__main__":
+    description = ("A utility for invoking clang-format to look at the C++ "
+                   "code formatting in the repository. It produces "
+                   "reports of style metrics and also can apply formatting.")
+    parser = argparse.ArgumentParser(description=description)
+    subparsers = parser.add_subparsers()
+    add_report_cmd(subparsers)
+    add_check_cmd(subparsers)
+    add_format_cmd(subparsers)
+    settings = parser.parse_args()
+    if not hasattr(settings, "cmd"):
+        parser.print_help()
+        sys.exit("*** missing argument")
+    finish_clang_settings(settings)
+    settings.cmd(settings).run()

--- a/bin/clang_static_analysis.py
+++ b/bin/clang_static_analysis.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import os
+import time
+import argparse
+import json
+
+from framework.print.buffer import PrintBuffer
+from framework.argparse.option import add_jobs_option
+from framework.argparse.option import add_json_option
+from framework.git.parameter import add_git_repository_parameter
+from framework.cmd.repository import RepositoryCmd
+from framework.clang.option import add_clang_options
+from framework.clang.option import finish_clang_settings
+
+
+###############################################################################
+# cmd base class
+###############################################################################
+
+class ClangStaticAnalysisCmd(RepositoryCmd):
+    """
+    Superclass for a command that runs clang static analysis.
+    """
+    def __init__(self, settings):
+        assert hasattr(settings, 'scan_build')
+        super().__init__(settings)
+        self.json = settings.json
+        self.scan_build = settings.scan_build
+
+    def _exec(self):
+        start_time = time.time()
+        self.scan_build.cleaner.run(silent=self.json)
+        self.scan_build.run(silent=self.json)
+        elapsed_time = time.time() - start_time
+        directory, issues = self.scan_build.get_results()
+        return {'elapsed_time':      time.time() - start_time,
+                'results_directory': directory,
+                'issues':            issues}
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        r = results
+        b.separator()
+        b.add("Took %.2f seconds to analyze with scan-build\n" %
+              r['elapsed_time'])
+        b.add("Found %d issues:\n" % len(r['issues']))
+        b.separator()
+        return str(b)
+
+    def _shell_exit(self, results):
+        return 0
+
+
+###############################################################################
+# report cmd
+###############################################################################
+
+class ReportCmd(ClangStaticAnalysisCmd):
+    """
+    'report' subcommand class.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "Clang Static Analysis Report"
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        b.add(super()._output(results))
+        r = results
+        issue_no = 0
+        for issue in r['issues']:
+            b.add("%d: %s:%d:%d - %s\n" % (issue_no, issue['file'],
+                                           issue['line'], issue['col'],
+                                           issue['description']))
+            issue_no = issue_no + 1
+        if len(r['issues']) > 0:
+            viewer = self.scan_build.viewer
+            b.add(viewer.launch_instructions(r['results_directory']))
+        return str(b)
+
+
+def add_report_cmd(subparsers):
+    report_help = ("Runs clang static analysis and produces a summary report "
+                   "of the findings.")
+    parser = subparsers.add_parser('report', help=report_help)
+    parser.set_defaults(cmd=lambda o: ReportCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_clang_options(parser, report_path=True)
+    add_git_repository_parameter(parser)
+
+
+###############################################################################
+# check cmd
+###############################################################################
+
+class CheckCmd(ClangStaticAnalysisCmd):
+    """
+    'check' subcommand class.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "Clang Static Analysis Check"
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        b.add(super()._output(results))
+        r = results
+        for issue in r['issues']:
+            b.add("An issue has been found in ")
+            b.add_red("%s:%d:%d\n" % (issue['file'], issue['line'],
+                                      issue['col']))
+            b.add("Type:         %s\n" % issue['type'])
+            b.add("Description:  %s\n\n" % issue['description'])
+            event_no = 0
+            for event in issue['events']:
+                b.add("%d: " % event_no)
+                b.add("%s:%d:%d - " % (event['file'], event['line'],
+                                       event['col']))
+                b.add("%s\n" % event['message'])
+                event_no = event_no + 1
+            b.separator()
+        if len(r['issues']) == 0:
+            b.add_green("No static analysis issues found!\n")
+            b.separator()
+        else:
+            viewer = self.scan_build.viewer
+            b.add(viewer.launch_instructions(r['results_directory']))
+        return str(b)
+
+    def _shell_exit(self, results):
+        return (0 if len(results['issues']) == 0 else
+                "*** static analysis issues found.")
+
+
+def add_check_cmd(subparsers):
+    check_help = ("Runs clang static analysis and output details for each "
+                  "discovered issue. Returns a non-zero shell status if any "
+                  "issues are found.")
+    parser = subparsers.add_parser('check', help=check_help)
+    parser.set_defaults(cmd=lambda o: CheckCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_clang_options(parser, report_path=True)
+    add_git_repository_parameter(parser)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("A utility for running clang static analysis on a codebase "
+                   "in a consistent way.")
+    parser = argparse.ArgumentParser(description=description)
+    subparsers = parser.add_subparsers()
+    add_report_cmd(subparsers)
+    add_check_cmd(subparsers)
+    settings = parser.parse_args()
+    if not hasattr(settings, "cmd"):
+        parser.print_help()
+        sys.exit("*** missing argument")
+    finish_clang_settings(settings)
+    settings.cmd(settings).run()

--- a/bin/clone_configure_build.py
+++ b/bin/clone_configure_build.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.argparse.option import add_jobs_option
+from framework.bitcoin.clone import DEFAULT_UPSTREAM_URL
+from framework.bitcoin.setup import bitcoin_setup_build_ready_repo
+from framework.build.make import Make
+
+
+def add_url_option(parser):
+    u_help = "upstream url to clone from (default=%s)" % DEFAULT_UPSTREAM_URL
+    parser.add_argument('-u', "--clone-url", type=str,
+                        default=DEFAULT_UPSTREAM_URL, help=u_help)
+
+
+def add_branch_option(parser):
+    b_help = "branch to checkout before building (default=master)"
+    parser.add_argument('-b', "--git-branch", type=str, default='master',
+                        help=b_help)
+
+
+def add_directory_argument(parser):
+    d_help = "Directory to hold the repository clone."
+    parser.add_argument('directory', type=str, help=d_help)
+
+
+if __name__ == "__main__":
+    description = ("Clones and builds a bitcoin repository with standard "
+                   "settings. BerkeleyDB 4.8 is also downloaded to the "
+                   "temporary directory and built as part of the process.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    add_jobs_option(parser)
+    add_url_option(parser)
+    add_branch_option(parser)
+    add_directory_argument(parser)
+    settings = parser.parse_args()
+    repository = (
+        bitcoin_setup_build_ready_repo(settings.tmp_directory,
+                                       clone_directory=settings.directory,
+                                       upstream_url=settings.clone_url,
+                                       branch=settings.git_branch))
+    make_log = os.path.join(settings.tmp_directory, 'make.log')
+    maker = Make(str(repository), make_log, jobs=settings.jobs)
+    maker.run()

--- a/bin/copyright_header.py
+++ b/bin/copyright_header.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import re
+import sys
+import argparse
+import json
+
+from framework.print.buffer import PrintBuffer
+from framework.file.filter import FileFilter
+from framework.file.info import FileInfo
+from framework.cmd.file_content import FileContentCmd
+from framework.argparse.option import add_jobs_option
+from framework.argparse.option import add_json_option
+from framework.git.parameter import add_git_tracked_targets_parameter
+from framework.git.path import GitFilePath
+
+
+APPLIES_TO = ['*.h', '*.cpp', '*.py', '*.sh', '*.am', '*.m4', '*.include']
+
+###############################################################################
+# regexes
+###############################################################################
+
+YEAR = "20[0-9][0-9]"
+YEAR_RANGE = '(?P<start_year>%s)(-(?P<end_year>%s))?' % (YEAR, YEAR)
+
+YEAR_RANGE_COMPILED = re.compile(YEAR_RANGE)
+
+###############################################################################
+# header regex
+###############################################################################
+
+HOLDERS = [
+    "Satoshi Nakamoto",
+    "The Bitcoin Core developers",
+    "Pieter Wuille",
+    "Wladimir J\\. van der Laan",
+    "Jeff Garzik",
+    "BitPay Inc\\.",
+    "MarcoFalke",
+    "ArtForz -- public domain half-a-node",
+    "Jeremy Rubin",
+]
+ANY_HOLDER = '|'.join([h for h in HOLDERS])
+COPYRIGHT_LINE = (
+    "(#|//|dnl) Copyright \\(c\\) %s (%s)" % (YEAR_RANGE, ANY_HOLDER))
+LAST_TWO_LINES = ("(#|//|dnl) Distributed under the MIT software license, see "
+                  "the accompanying\n(#|//|dnl) file COPYING or "
+                  "http://www\\.opensource\\.org/licenses/mit-license\\.php\\."
+                  "\n")
+
+HEADER = "(%s\n)+%s" % (COPYRIGHT_LINE, LAST_TWO_LINES)
+
+HEADER_COMPILED = re.compile(HEADER)
+
+
+ISSUE_1 = {
+    'description': "A valid header was expected, but the file does not match "
+                   "the regex.",
+    'resolution': """
+A correct MIT License header copyrighted by 'The Bitcoin Core developers' in
+the present year can be inserted into a file by running:
+
+    $ ./copyright_header.py insert <filename>
+
+If there was a preexisting invalid header in the file, that will need to be
+manually deleted. If there is a new copyright holder for the MIT License, the
+holder will need to be added to the HOLDERS list to include it in the regex
+check.
+"""
+}
+
+ISSUE_2 = {
+    'description': "A valid header was found in the file, but it wasn't "
+                   "expected.",
+    'resolution': """
+The header was not expected due to a setting. If a valid copyright header has
+been added to the file, the filename can be removed from the
+'no_copyright_header_expected' settings.
+"""
+}
+
+ISSUE_3 = {
+    'description': "Another 'copyright' occurrence was found, but it wasn't "
+                   "expected.",
+    'resolution': """
+This file's body has a regular expression match for the (case-sensitive) words
+"Copyright", "COPYRIGHT" or 'copyright". If this was an appropriate addition,
+the file can be added to the 'other_copyright_occurrences_expected' settings.
+"""
+}
+
+ISSUE_4 = {
+    'description': "Another 'copyright' occurrence was expected, but wasn't "
+                   "found.",
+    'resolution': """
+A use of the (case-sensitive) words "Copyright", "COPYRIGHT", or 'copyright'
+outside of the regular copyright header was expected due to a setting but it
+was not found. If this was an appropriate removal, it can be removed from the
+'other_copyright_occurrences_expected' settings.
+"""
+}
+
+NO_ISSUE = {
+    'description': "Everything is excellent",
+    'resolution': "(none)"
+}
+
+ISSUES = [ISSUE_1, ISSUE_2, ISSUE_3, ISSUE_4, NO_ISSUE]
+
+
+SCRIPT_HEADER = ("# Copyright (c) %s The Bitcoin Core developers\n"
+                 "# Distributed under the MIT software license, see the "
+                 "accompanying\n# file COPYING or http://www.opensource.org/"
+                 "licenses/mit-license.php.\n")
+
+CPP_HEADER = ("// Copyright (c) %s The Bitcoin Core developers\n// "
+              "Distributed under the MIT software license, see the "
+              "accompanying\n// file COPYING or http://www.opensource.org/"
+              "licenses/mit-license.php.\n")
+
+OTHER_COPYRIGHT = "(Copyright|COPYRIGHT|copyright)"
+OTHER_COPYRIGHT_COMPILED = re.compile(OTHER_COPYRIGHT)
+
+###############################################################################
+# file info
+###############################################################################
+
+class CopyrightHeaderFileInfo(FileInfo):
+    """
+    Obtains and represents the information regarding a single file.
+    """
+    def __init__(self, repository, file_path, copyright_expected,
+                 other_copyright_expected):
+        super().__init__(repository, file_path)
+        self['hdr_expected'] = copyright_expected
+        self['other_copyright_expected'] = other_copyright_expected
+
+    def _starts_with_shebang(self):
+        if len(self['content']) < 2:
+            return False
+        return self['content'][:2] == '#!'
+
+    def _header_match_in_correct_place(self, header_match):
+        start = header_match.start(0)
+        if start == 0:
+            return not self['shebang']
+        return self['shebang'] and (self['content'][:start].count('\n') == 1)
+
+    def _has_header(self):
+        header_match = HEADER_COMPILED.search(self['content'])
+        if not header_match:
+            return False
+        return self._header_match_in_correct_place(header_match)
+
+    def _has_copyright_in_region(self, content_region):
+        return OTHER_COPYRIGHT_COMPILED.search(content_region) is not None
+
+    def _has_other_copyright(self):
+        # look for the OTHER_COPYRIGHT regex outside the normal header regex
+        # match
+        header_match = HEADER_COMPILED.search(self['content'])
+        region = (self['content'][header_match.end():] if header_match else
+                  self['content'])
+        return self._has_copyright_in_region(region)
+
+    def _evaluate(self):
+        if not self['has_header'] and self['hdr_expected']:
+            return ISSUE_1
+        if self['has_header'] and not self['hdr_expected']:
+            return ISSUE_2
+        if self['has_other'] and not self['other_copyright_expected']:
+            return ISSUE_3
+        if not self['has_other'] and self['other_copyright_expected']:
+            return ISSUE_4
+        return NO_ISSUE
+
+    def compute(self):
+        self['shebang'] = self._starts_with_shebang()
+        self['has_header'] = self._has_header()
+        self['has_other'] = self._has_other_copyright()
+        self['evaluation'] = self._evaluate()
+        self['pass'] = self['evaluation'] is NO_ISSUE
+
+
+###############################################################################
+# cmd base class
+###############################################################################
+
+class CopyrightHeaderCmd(FileContentCmd):
+    """
+    Common base class for the commands in this script.
+    """
+    def __init__(self, settings):
+        settings.include_fnmatches = APPLIES_TO
+        super().__init__(settings)
+        self.no_copyright_filter = FileFilter()
+        repo_info = self.repository.repo_info
+        self.no_copyright_filter.append_include(
+            repo_info['no_copyright_header_expected']['fnmatches'],
+            base_path=str(self.repository))
+        self.other_copyright_filter = FileFilter()
+        self.other_copyright_filter.append_include(
+            repo_info['other_copyright_occurrences_expected']['fnmatches'],
+            base_path=str(self.repository))
+
+    def _copyright_expected(self, file_path):
+        return not self.no_copyright_filter.evaluate(file_path)
+
+    def _other_copyright_expected(self, file_path):
+        return self.other_copyright_filter.evaluate(file_path)
+
+    def _file_info_list(self):
+        return [CopyrightHeaderFileInfo(self.repository, f,
+                                        self._copyright_expected(f),
+                                        self._other_copyright_expected(f))
+                for f in self.files_targeted]
+
+
+###############################################################################
+# report cmd
+###############################################################################
+
+class ReportCmd(CopyrightHeaderCmd):
+    """
+    'report' subcommand class.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "Copyright Header Report"
+
+    def _exec(self):
+        r = super()._exec()
+        r['hdr_expected'] = sum(1 for f in self.file_infos if
+                                f['hdr_expected'])
+        r['no_hdr_expected'] = sum(1 for f in self.file_infos if not
+                                   f['hdr_expected'])
+        r['other_copyright_expected'] = sum(1 for f in self.file_infos if
+                                            f['other_copyright_expected'])
+        r['no_other_copyright_expected'] = sum(
+            1 for f in self.file_infos if not f['other_copyright_expected'])
+        r['passed'] = sum(1 for f in self.file_infos if f['pass'])
+        r['failed'] = sum(1 for f in self.file_infos if not f['pass'])
+        r['issues'] = {}
+        for issue in ISSUES:
+            r['issues'][issue['description']] = sum(
+                1 for f in self.file_infos if
+                f['evaluation']['description'] == issue['description'])
+        return r
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        r = results
+        b.add(super()._output(results))
+        b.add("%-70s %6d\n" % ("Files expected to have header:",
+                               r['hdr_expected']))
+        b.add("%-70s %6d\n" % ("Files not expected to have header:",
+                               r['no_hdr_expected']))
+        b.add("%-70s %6d\n" %
+              ("Files expected to have 'copyright' occurrence outside header:",
+               r['other_copyright_expected']))
+        b.add("%-70s %6d\n" %
+              ("Files not expected to have 'copyright' occurrence outside "
+               "header:", r['no_other_copyright_expected']))
+        b.add("%-70s %6d\n" % ("Files passed:", r['passed']))
+        b.add("%-70s %6d\n" % ("Files failed:", r['failed']))
+        b.separator()
+        for key, value in sorted(r['issues'].items()):
+            b.add("%-70s %6d\n" % ('"' + key + '":', value))
+        b.separator()
+        return str(b)
+
+
+def add_report_cmd(subparsers):
+    report_help = ("Produces a report of copyright header notices within "
+                   "selected targets to help identify files that don't meet "
+                   "expectations.")
+    parser = subparsers.add_parser('report', help=report_help)
+    parser.set_defaults(cmd=lambda o: ReportCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# check cmd
+###############################################################################
+
+class CheckCmd(CopyrightHeaderCmd):
+    """
+    'check' subcommand class.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "Copyright Header Check"
+
+    def _exec(self):
+        r = super()._exec()
+        r['issues'] = [{'file_path':  f['file_path'],
+                        'evaluation': f['evaluation']} for f in
+                       self.file_infos if not f['pass']]
+        return r
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        b.add(super()._output(results))
+        r = results
+        for issue in r['issues']:
+            b.add("An issue was found with ")
+            b.add_red("%s" % issue['file_path'])
+            b.add('\n\n%s\n\n' % issue['evaluation']['description'])
+            b.add('Info for resolution:\n')
+            b.add(issue['evaluation']['resolution'])
+            b.separator()
+        if len(r['issues']) == 0:
+            b.add_green("No copyright header issues found!\n")
+        return str(b)
+
+    def _shell_exit(self, results):
+        return (0 if len(results['issues']) == 0 else
+                "*** copyright header issue found")
+
+
+def add_check_cmd(subparsers):
+    check_help = ("Validates that selected targets do not have copyright "
+                  "header issues, gives a per-file report and returns a "
+                  "non-zero shell status if there are any issues discovered.")
+    parser = subparsers.add_parser('check', help=check_help)
+    parser.set_defaults(cmd=lambda o: CheckCmd(o))
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# update cmd
+###############################################################################
+
+COPYRIGHT = 'Copyright \\(c\\)'
+HOLDER = 'The Bitcoin Core developers'
+UPDATEABLE_LINE_COMPILED = re.compile(' '.join([COPYRIGHT, YEAR_RANGE,
+                                                HOLDER]))
+
+
+class UpdateCmd(CopyrightHeaderCmd):
+    """
+    'update' subcommand class.
+    """
+    def __init__(self, settings):
+        settings.json = False
+        settings.jobs = 1
+        super().__init__(settings)
+        self.title = "Copyright Header Update"
+
+    def _updatable_copyright_line(self, file_lines):
+        index = 0
+        for line in file_lines:
+            if UPDATEABLE_LINE_COMPILED.search(line) is not None:
+                return index, line
+            index = index + 1
+        return None, None
+
+    def _year_range_to_str(self, start_year, end_year):
+        if start_year == end_year:
+            return start_year
+        return "%s-%s" % (start_year, end_year)
+
+    def _updated_copyright_line(self, line, last_git_change_year):
+        match = YEAR_RANGE_COMPILED.search(line)
+        start_year = match.group('start_year')
+        end_year = match.group('end_year')
+        if end_year is None:
+            end_year = start_year
+        if end_year == last_git_change_year:
+            return line
+        new_range_str = self._year_range_to_str(start_year,
+                                                last_git_change_year)
+        return YEAR_RANGE_COMPILED.sub(new_range_str, line)
+
+    def _update_header(self, file_info):
+        file_lines = file_info['content'].split('\n')
+        index, line = self._updatable_copyright_line(file_lines)
+        if line is None:
+            return file_info['content']
+        last_git_change_year = file_info['change_years'][1]
+        new_line = self._updated_copyright_line(line, last_git_change_year)
+        if line == new_line:
+            return file_info['content']
+        file_lines[index] = new_line
+        return'\n'.join(file_lines)
+
+    def _compute_file_infos(self):
+        super()._compute_file_infos()
+        if not self.silent:
+            print("Querying git for file update history...")
+        for file_info in self.file_infos:
+            file_path = GitFilePath(file_info['file_path'])
+            file_info['change_years'] = file_path.change_year_range()
+            updated = self._update_header(file_info)
+            file_info['updated'] = updated != file_info['content']
+            file_info.set_write_content(updated)
+        if not self.silent:
+            print("Done.")
+
+    def _exec(self):
+        super()._exec()
+        self.file_infos.write_all()
+        if not self.silent:
+            print("Updated copyright header years in %d files." %
+                  sum(1 for f in self.file_infos if f['updated']))
+
+    def _output(self, results):
+        return None
+
+
+def add_update_cmd(subparsers):
+    update_help = ('Updates the end year of the copyright headers of '
+                   '"The Bitcoin Core developers" in files amongst the '
+                   'selected targets which have been changed more recently '
+                   'than the year that is listed.')
+    parser = subparsers.add_parser('update', help=update_help)
+    parser.set_defaults(cmd=lambda o: UpdateCmd(o))
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# insert cmd
+###############################################################################
+
+ALL_EXTS = [s[1:] for s in APPLIES_TO if s[0] is '*']
+
+SCRIPT_HEADER = ("# Copyright (c) %s The Bitcoin Core developers\n"
+                 "# Distributed under the MIT software license, see the "
+                 "accompanying\n# file COPYING or http://www.opensource.org/"
+                 "licenses/mit-license.php.\n")
+
+SCRIPT_EXTS = ['.py', '.sh', '.am', '.include']
+
+M4_HEADER = ("dnl Copyright (c) %s The Bitcoin Core developers\n"
+             "dnl Distributed under the MIT software license, see the "
+             "accompanying\ndnl file COPYING or http://www.opensource.org/"
+             "licenses/mit-license.php.\n")
+
+M4_EXTS = ['.m4']
+
+CPP_HEADER = ("// Copyright (c) %s The Bitcoin Core developers\n// "
+              "Distributed under the MIT software license, see the "
+              "accompanying\n// file COPYING or http://www.opensource.org/"
+              "licenses/mit-license.php.\n")
+
+CPP_EXTS = ['.h', '.cpp']
+
+assert set(ALL_EXTS) == set(SCRIPT_EXTS + M4_EXTS + CPP_EXTS)
+
+
+class InsertCmd(CopyrightHeaderCmd):
+    """
+    'insert' subcommand class.
+    """
+    def __init__(self, settings):
+        settings.json = False
+        settings.jobs = 1
+        super().__init__(settings)
+        self.title = "Copyright Header Insert"
+
+    def _year_range_string(self, start_year, end_year):
+        if start_year == end_year:
+            return start_year
+        return "%s-%s" % (start_year, end_year)
+
+    def _header(self, file_path, start_year, end_year):
+        file_path.assert_extension_is_one_of(ALL_EXTS)
+        year_range = self._year_range_string(start_year, end_year)
+        if file_path.extension_is_one_of(SCRIPT_EXTS):
+            return SCRIPT_HEADER % year_range
+        if file_path.extension_is_one_of(M4_EXTS):
+            return CPP_HEADER % year_range
+        else:
+            return M4_HEADER % year_range
+
+    def _content_with_header(self, file_info):
+        file_path = GitFilePath(file_info['file_path'])
+        start_year, end_year = file_path.change_year_range()
+        header = self._header(file_path, start_year, end_year)
+        insertion_point = (file_info['content'].find('\n') + 1 if
+                           file_info['shebang'] else 0)
+        content = file_info['content']
+        return content[:insertion_point] + header + content[insertion_point:]
+
+    def _compute_file_infos(self):
+        super()._compute_file_infos()
+        for file_info in self.file_infos:
+            header_needed = (file_info['hdr_expected'] and not
+                             file_info['has_header'])
+            to_write = (self._content_with_header(file_info) if
+                        header_needed else file_info['content'])
+            file_info['hdr_added'] = header_needed
+            file_info.set_write_content(to_write)
+
+    def _exec(self):
+        super()._exec()
+        self.file_infos.write_all()
+        if not self.silent:
+            print("Added copyright header to %d files." %
+                  sum(1 for f in self.file_infos if f['hdr_added']))
+
+    def _output(self, results):
+        return None
+
+
+def add_insert_cmd(subparsers):
+    insert_help = ('Inserts a correct MIT-licence copyright header for "The '
+                   'Bitcoin Core developers" at the top of files amongst the '
+                   'selected targets where the header is expected but not '
+                   'currently found.')
+    parser = subparsers.add_parser('insert', help=insert_help)
+    parser.set_defaults(cmd=lambda o: InsertCmd(o))
+    add_git_tracked_targets_parameter(parser)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("utilities for managing copyright headers of 'The Bitcoin "
+                   "Core developers' in repository source files")
+    parser = argparse.ArgumentParser(description=description)
+    subparsers = parser.add_subparsers()
+    add_report_cmd(subparsers)
+    add_check_cmd(subparsers)
+    add_update_cmd(subparsers)
+    add_insert_cmd(subparsers)
+    settings = parser.parse_args()
+    if not hasattr(settings, "cmd"):
+        parser.print_help()
+        sys.exit("*** missing argument")
+    settings.cmd(settings).run()

--- a/bin/framework
+++ b/bin/framework
@@ -1,0 +1,1 @@
+../framework

--- a/bin/reports.py
+++ b/bin/reports.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import argparse
+
+from framework.cmd.repository import RepositoryCmds
+from clang_static_analysis import ReportCmd as ClangStaticAnalysisReport
+from basic_style import ReportCmd as BasicStyleReport
+from copyright_header import ReportCmd as CopyrightHeaderReport
+from clang_format import ReportCmd as ClangFormatReport
+from framework.argparse.option import add_jobs_option
+from framework.argparse.option import add_json_option
+from framework.clang.option import add_clang_options
+from framework.clang.option import finish_clang_settings
+from framework.git.parameter import add_git_tracked_targets_parameter
+
+
+class Reports(RepositoryCmds):
+    """
+    Invokes several underlying RepositoryCmd report command instances and
+    aggregates them into a single report.
+    """
+    def __init__(self, settings):
+        repository_cmds = {
+            'copyright_header':      CopyrightHeaderReport(settings),
+            'basic_style':           BasicStyleReport(settings),
+            'clang_format':          ClangFormatReport(settings),
+            'clang_static_analysis': ClangStaticAnalysisReport(settings),
+        }
+        self.json = settings.json
+        super().__init__(settings, repository_cmds, silent=settings.json)
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        reports = [(self.repository_cmds[l].title + ":\n" +
+                    self.repository_cmds[l]._output(r)) for l, r in
+                   sorted(results.items())]
+        return '\n'.join(reports)
+
+
+if __name__ == "__main__":
+    description = ("Wrapper to invoke a collection of scripts that produce "
+                   "data from analyzing a repository.")
+    parser = argparse.ArgumentParser(description=description)
+    add_jobs_option(parser)
+    add_json_option(parser)
+    add_clang_options(parser, report_path=True, style_file=True)
+    add_git_tracked_targets_parameter(parser)
+    settings = parser.parse_args()
+    finish_clang_settings(settings)
+    reports = Reports(settings)
+    reports.run()

--- a/framework/README.md
+++ b/framework/README.md
@@ -1,0 +1,12 @@
+Contents
+========
+This directory contains common infrastructure for bitcoin maintainer scripts.
+
+File, Subdirectory and Namspace Convention
+==========================================
+
+The subdirectory, file and class names are meant to follow a semi-consistent pattern. This is not a strict requirement, but use it as guidance for keeping the layout reasonably modular, organized and intuitive.
+
+To illustrate the convention, the class `GitRepository` is found in `git/repository.py`. The file and the class encapsulate the concept of a git repository and is placed in the `git` subdirectory with other git-related concepts. The `ClangTarball` class is therefore located in `clang/tarball.py` following the same convention.
+
+Please attempt to follow this convention for new code.

--- a/framework/argparse/action.py
+++ b/framework/argparse/action.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import argparse
+import tempfile
+
+from framework.path.path import Path
+
+
+class TmpDirectoryAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, str):
+            sys.exit("*** %s is not a single string" % values)
+        if not str(values).startswith(tempfile.gettempdir()):
+            sys.exit("*** %s is not under %s" % (p, tempfile.gettempdir()))
+        namespace.tmp_directory = str(Path(values))

--- a/framework/argparse/option.py
+++ b/framework/argparse/option.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import tempfile
+import os
+
+from framework.argparse.action import TmpDirectoryAction
+
+
+def add_jobs_option(parser):
+    j_help = "parallel jobs (default=4)"
+    parser.add_argument("-j", "--jobs", type=int, default=4, help=j_help)
+
+
+def add_json_option(parser):
+    j_help = "print output in json format (default=False)"
+    parser.add_argument("--json", action='store_true', help=j_help)
+
+
+DEFAULT_TMP_DIR = os.path.join(tempfile.gettempdir(),
+                               'bitcoin-maintainer-tools/')
+
+
+def add_tmp_directory_option(parser):
+    r_help = ("path for the maintainer tools to write temporary files."
+              "(default=%s)" % DEFAULT_TMP_DIR)
+    parser.add_argument("-t", "--tmp-directory", default=DEFAULT_TMP_DIR,
+                        type=str, action=TmpDirectoryAction, help=r_help)

--- a/framework/berkeleydb/build.py
+++ b/framework/berkeleydb/build.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import shutil
+
+from framework.build.make import Make
+from framework.build.configure import Configure
+from framework.berkeleydb.download import BerkeleyDbDownload
+
+SRC_SUBDIR = "db-4.8.30.NC"
+BUILD_TARGET_SUBDIR = "berkeleydb-install"
+BUILD_FROM_SUBDIR = "build_unix"
+CONFIGURE_SCRIPT = "../dist/configure"
+CONFIGURE_OUTFILE = "bdb-configure.log"
+CONFIGURE_OPTIONS = "--enable-cxx --disable-shared --with-pic --prefix=%s"
+MAKE_OUTFILE = "bdb-make-install.log"
+
+
+class BerkeleyDbBuild(object):
+    """
+    Produces a build and installed subdirectory for Bitoin's build process to
+    use. The instructions from build-unix.md are automated and the prefix to
+    use for Bitcoin's ./configure step is made available.
+    """
+    def __init__(self, directory, silent=False):
+        self.directory = directory
+        self.silent = silent
+        self.build_target_dir = os.path.join(self.directory,
+                                             BUILD_TARGET_SUBDIR)
+        self.src_dir = os.path.join(self.directory, SRC_SUBDIR)
+        self.build_from_dir = os.path.join(self.src_dir, BUILD_FROM_SUBDIR)
+        self.configure_outfile = os.path.join(self.directory,
+                                              CONFIGURE_OUTFILE)
+        self.make_outfile = os.path.join(self.directory, MAKE_OUTFILE)
+        self.downloader = BerkeleyDbDownload(self.directory,
+                                             silent=self.silent)
+        self._prep_directory()
+
+    def _prep_directory(self):
+        if not os.path.exists(self.directory):
+            os.makedirs(self.directory)
+        if os.path.exists(self.build_target_dir):
+            shutil.rmtree(self.build_target_dir)
+        os.makedirs(self.build_target_dir)
+        if os.path.exists(self.src_dir):
+            shutil.rmtree(self.src_dir)
+
+    def prefix(self):
+        return self.build_target_dir
+
+    def build(self):
+        self.downloader.download()
+        self.downloader.verify()
+        self.downloader.unpack()
+        options = CONFIGURE_OPTIONS % self.prefix()
+        self.configurator = Configure(self.build_from_dir,
+                                      self.configure_outfile,
+                                      script=CONFIGURE_SCRIPT, options=options)
+        self.configurator.run(silent=self.silent)
+        self.maker = Make(self.build_from_dir, self.make_outfile,
+                          target="install")
+        self.maker.run(silent=self.silent)

--- a/framework/berkeleydb/download.py
+++ b/framework/berkeleydb/download.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+import urllib.request as Download
+
+from framework.file.hash import FileHash
+
+TARBALL = "db-4.8.30.NC.tar.gz"
+DOWNLOAD_URL = "http://download.oracle.com/berkeley-db/" + TARBALL
+CHECKSUM = "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef"
+UNTAR = "tar -xzf " + TARBALL
+
+
+class BerkeleyDbDownload(object):
+    """
+    Downloads, verifies and unpacks the BerkeleyDB tarball from Oracle.
+    """
+    def __init__(self, directory, silent=False):
+        self.directory = directory
+        self.silent = silent
+        self.tarball = os.path.join(self.directory, TARBALL)
+
+    def download(self):
+        if os.path.exists(self.tarball):
+            # To avoid abusing Oracle's server, don't re-download if we
+            # already have the tarball.
+            if not self.silent:
+                print("Found %s" % (self.tarball))
+            return
+        if not self.silent:
+            print("Downloading %s..." % DOWNLOAD_URL)
+        Download.urlretrieve(DOWNLOAD_URL, self.tarball)
+        if not self.silent:
+            print("Done.")
+
+    def verify(self):
+        if not str(FileHash(self.tarball)) == CHECKSUM:
+            sys.exit("*** %s does not have expected hash %s" % (self.tarball,
+                                                                CHECKSUM))
+
+    def unpack(self):
+        original_dir = os.getcwd()
+        os.chdir(self.directory)
+        rc = subprocess.call(UNTAR.split(" "))
+        os.chdir(original_dir)
+        if rc != 0:
+            sys.exit("*** could not unpack %s" % self.tarball)

--- a/framework/berkeleydb/setup.py
+++ b/framework/berkeleydb/setup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+
+from framework.berkeleydb.download import BerkeleyDbDownload
+from framework.bitcoin.setup import BDB_DIR
+
+
+def berkeleydb_setup_dir(directory):
+    bdb_dir = os.path.join(directory, BDB_DIR)
+    if not os.path.exists(str(bdb_dir)):
+        os.makedirs(str(bdb_dir))
+    downloader = BerkeleyDbDownload(bdb_dir)
+    downloader.download()
+    downloader.verify()
+    downloader.unpack()
+    return bdb_dir

--- a/framework/bitcoin/clone.py
+++ b/framework/bitcoin/clone.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+
+from framework.git.clone import GitClone
+
+DEFAULT_UPSTREAM_URL = "https://github.com/bitcoin/bitcoin/"
+
+
+class BitcoinClone(object):
+    """
+    Clones a bitcoin repository to a directory. If the directory already
+    exists, just fetch changes from upstream to avoid re-downloading.
+    """
+    def __init__(self, directory, upstream_url=DEFAULT_UPSTREAM_URL,
+                 silent=False):
+        self.directory = directory
+        self.upstream_url = upstream_url
+        self.cloner = GitClone(self.upstream_url, silent=silent)
+
+    def clone(self):
+        self.cloner.clone_or_fetch(self.directory)

--- a/framework/bitcoin/repository.py
+++ b/framework/bitcoin/repository.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+
+from framework.bitcoin.clone import BitcoinClone, DEFAULT_UPSTREAM_URL
+from framework.git.repository import GitRepository
+from framework.berkeleydb.build import BerkeleyDbBuild
+from framework.build.autogen import Autogen
+from framework.build.configure import Configure
+
+
+class BitcoinRepository(GitRepository):
+    """
+    A git repository that is specifically a bitcoin repository.
+    """
+    def __init__(self, directory, clone=False,
+                 upstream_url=DEFAULT_UPSTREAM_URL, silent=False):
+        self.directory = directory
+        self.silent = silent
+        if clone:
+            BitcoinClone(self.directory, upstream_url=upstream_url,
+                         silent=self.silent).clone()
+        super().__init__(self.directory)
+
+    def build_prepare(self, bdb_directory, autogen_log, configure_log):
+        """
+        Downloads and builds BerkeleyDb, runs ./autogen.sh and ./configure
+        with the prefix set to the built BerkeleyDb.
+        """
+        bdb = BerkeleyDbBuild(bdb_directory, silent=self.silent)
+        bdb.build()
+        prefix = bdb.prefix()
+        Autogen(self.directory, autogen_log).run()
+        options = "LDFLAGS=-L%s/lib/ CPPFLAGS=-I%s/include/" % (prefix, prefix)
+        Configure(self.directory, configure_log, options=options).run()

--- a/framework/bitcoin/setup.py
+++ b/framework/bitcoin/setup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+
+from framework.bitcoin.clone import DEFAULT_UPSTREAM_URL
+from framework.bitcoin.repository import BitcoinRepository
+
+DEFAULT_CLONE_DIR = "bitcoin"
+BDB_DIR = "berkeley-db"
+AUTOGEN_LOG = "autogen.log"
+CONFIGURE_LOG = "configure.log"
+TEST_BRANCH = "v0.14.0"
+
+
+def bitcoin_setup_repo(tmp_directory, clone_directory=None,
+                       upstream_url=DEFAULT_UPSTREAM_URL,
+                       branch=TEST_BRANCH, silent=False):
+    if not clone_directory:
+        clone_directory = os.path.join(tmp_directory, DEFAULT_CLONE_DIR)
+    repository = BitcoinRepository(clone_directory, clone=True,
+                                   upstream_url=upstream_url, silent=silent)
+    repository.reset_hard(branch)
+    return repository
+
+
+def bitcoin_setup_build_ready_repo(tmp_directory, clone_directory=None,
+                                   upstream_url=DEFAULT_UPSTREAM_URL,
+                                   branch=TEST_BRANCH, silent=False):
+    repository = bitcoin_setup_repo(tmp_directory,
+                                    clone_directory=clone_directory,
+                                    upstream_url=upstream_url, branch=branch,
+                                    silent=silent)
+    bdb_dir = os.path.join(tmp_directory, BDB_DIR)
+    autogen_log = os.path.join(tmp_directory, AUTOGEN_LOG)
+    configure_log = os.path.join(tmp_directory, CONFIGURE_LOG)
+    repository.build_prepare(bdb_dir, autogen_log, configure_log)
+    return repository

--- a/framework/build/autogen.py
+++ b/framework/build/autogen.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from framework.build.step import BuildStep
+
+
+class Autogen(BuildStep):
+    """
+    Executes './autogen' on the source directory.
+    """
+    def _cmd(self):
+        return "./autogen.sh"

--- a/framework/build/configure.py
+++ b/framework/build/configure.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from framework.build.step import BuildStep
+
+
+class Configure(BuildStep):
+    """
+    Executes './configure' on the source directory.
+    """
+    def __init__(self, invocation_dir, output_file, script=None, options=None):
+        super().__init__(invocation_dir, output_file)
+        self.options = options
+        self.script = script
+
+    def _cmd(self):
+        if not self.script:
+            self.script = "./configure"
+        if not self.options:
+            self.options = ""
+        return "%s %s" % (self.script, self.options)

--- a/framework/build/make.py
+++ b/framework/build/make.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from framework.build.step import BuildStep
+
+
+class MakeClean(BuildStep):
+    """
+    Executes 'make clean' on the source directory.
+    """
+    def _cmd(self):
+        return "make clean"
+
+
+class Make(BuildStep):
+    """
+    Executes 'make' on the source directory.
+    """
+    def __init__(self, invocation_dir, output_file, jobs=1, target=None,
+                 options=None):
+        super().__init__(invocation_dir, output_file)
+        self.jobs = jobs
+        self.options = options
+        self.target = target
+
+    def _cmd(self):
+        args = ""
+        if self.jobs > 1:
+            args = args + " -j%d" % self.jobs
+        if self.options:
+            args = args + " %s" % self.options
+        if self.target:
+            args = args + " %s" % self.target
+        return "make%s" % args

--- a/framework/build/step.py
+++ b/framework/build/step.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+
+from framework.path.path import Path
+
+
+class BuildStep(object):
+    """
+    Superclass for running build operations on a git repository. The output
+    is routed to a specified file.
+    """
+    def __init__(self, invocation_dir, output_file):
+        path = Path(output_file)
+        containing_directory = Path(path.containing_directory())
+        if not os.path.exists(str(containing_directory)):
+            os.makedirs(str(containing_directory))
+        containing_directory.assert_exists()
+        containing_directory.assert_mode(os.R_OK | os.W_OK)
+        self.invocation_dir = invocation_dir
+        self.output_file = str(path)
+
+    def __str__(self):
+        return self._cmd()
+
+    def _cmd(self):
+        sys.exit("*** subclass must override _cmd() method.")
+
+    def run(self, silent=False):
+        if not silent:
+            print("Running command:     %s" % str(self))
+            print("stderr/stdout to:    %s" % self.output_file)
+            print("This might take a few minutes...")
+        cmd = self._cmd()
+        original_dir = os.getcwd()
+        os.chdir(self.invocation_dir)
+        f = open(os.path.abspath(self.output_file), 'w')
+        if subprocess.call(cmd.split(' '), stdout=f, stderr=f) != 0:
+            sys.exit("*** '%s' returned a non-zero status. log in %s" %
+                     (cmd, self.output_file))
+        f.close()
+        os.chdir(original_dir)
+        if not silent:
+            print("Done.")

--- a/framework/clang/download.py
+++ b/framework/clang/download.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+import urllib.request as Download
+
+from framework.file.hash import FileHash
+from framework.clang.tarball import ClangTarball
+
+UNTAR = "tar -xJf %s"
+
+
+class ClangDownload(object):
+    """
+    Downloads, verifies and unpacks a clang 3.9.0 release tarball that
+    matches the current platform from the LLVM project's servers.
+    """
+    def __init__(self, directory, silent=False):
+        self.directory = directory
+        self.silent = silent
+        self.tarball = ClangTarball()
+        if not self.tarball.supported:
+            sys.exit("*** couldn't find a clang tarball for this platform.")
+        self.download_path = os.path.join(self.directory,
+                                          self.tarball.filename())
+
+    def download(self):
+        if os.path.exists(self.download_path):
+            # To avoid abusing LLVM's server, don't re-download if we
+            # already have the tarball in the right place.
+            if not self.silent:
+                print("Found %s" % (self.download_path))
+            return
+        if not self.silent:
+            print("Downloading %s..." % self.tarball.url())
+        Download.urlretrieve(self.tarball.url(), self.download_path)
+        if not self.silent:
+            print("Done.")
+
+    def verify(self):
+        if not str(FileHash(self.download_path)) == self.tarball.sha256():
+            sys.exit("*** %s does not have expected hash %s" %
+                     (self.download_path, self.tarball.sha256()))
+
+    def unpack(self):
+        original_dir = os.getcwd()
+        os.chdir(self.directory)
+        cmd = UNTAR % self.tarball.filename()
+        rc = subprocess.call(cmd.split(" "))
+        os.chdir(original_dir)
+        if rc != 0:
+            sys.exit("*** could not unpack %s" % self.download_path)
+        return os.path.join(self.directory,
+                            self.tarball.unpacked_directory())

--- a/framework/clang/find.py
+++ b/framework/clang/find.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import os
+import re
+import subprocess
+
+from framework.path.path import Path
+
+
+# The clang binaries of interest to this framework
+CLANG_BINARIES = ['clang-format', 'scan-build', 'scan-view']
+
+# the method of finding the version of a particular binary:
+ASK_FOR_VERSION = ['clang-format']
+VERSION_FROM_PATH = ['scan-build', 'scan-view']
+
+assert set(ASK_FOR_VERSION + VERSION_FROM_PATH) == set(CLANG_BINARIES)
+
+# Find the version in the output of '--version'.
+VERSION_ASK_REGEX = re.compile("version (?P<version>[0-9]\.[0-9](\.[0-9])?)")
+
+# Find the version in the name of a containing subdirectory.
+VERSION_PATH_REGEX = re.compile("(?P<version>[0-9]\.[0-9](\.[0-9])?)")
+
+
+class ClangVersion(object):
+    """
+    Obtains and represents the version of a particular clang binary.
+    """
+    def __init__(self, binary_path):
+        p = Path(binary_path)
+        if p.filename() in ASK_FOR_VERSION:
+            self.version = self._version_from_asking(binary_path)
+        else:
+            self.version = self._version_from_path(binary_path)
+
+    def __str__(self):
+        return self.version
+
+    def _version_from_asking(self, binary_path):
+        p = subprocess.Popen([str(binary_path), '--version'],
+                             stdout=subprocess.PIPE)
+        match = VERSION_ASK_REGEX.search(p.stdout.read().decode('utf-8'))
+        if not match:
+            return "0.0.0"
+        return match.group('version')
+
+    def _version_from_path(self, binary_path):
+        match = VERSION_PATH_REGEX.search(str(binary_path))
+        if not match:
+            return "0.0.0"
+        return match.group('version')
+
+
+class ClangFind(object):
+    """
+    Assist finding clang tool binaries via either a parameter pointing to
+    a directory or by examinining the environment for installed binaries.
+    """
+    def __init__(self, path_arg_str=None):
+        if path_arg_str:
+            # Infer the directory from the provided path.
+            search_directories = [self._parameter_directory(path_arg_str)]
+        else:
+            # Use the directories with installed clang binaries
+            # in the PATH environment variable.
+            search_directories = list(set(self._installed_directories()))
+        self.binaries = self._find_binaries(search_directories)
+        if len(self.binaries) == 0:
+            sys.exit("*** could not locate clang binaries")
+
+    def _parameter_directory(self, path_arg_str):
+        p = Path(path_arg_str)
+        p.assert_exists()
+        # Tarball-download versions of clang put binaries in a bin/
+        # subdirectory. For convenience, tolerate a parameter of either:
+        # <unpacked_tarball>, <unpacked tarball>/bin or
+        # <unpacked_tarball>/bin/<specific_binary>
+        if p.is_file():
+            return p.directory()
+        bin_subdir = os.path.join(str(p), "bin/")
+        if os.path.exists(bin_subdir):
+            return bin_subdir
+        return str(p)
+
+    def _installed_directories(self):
+        for path in os.environ["PATH"].split(os.pathsep):
+            if not os.path.exists(path):
+                continue
+            for e in os.listdir(path):
+                b = Path(os.path.join(path, e))
+                if b.is_file() and b.filename() in CLANG_BINARIES:
+                    yield b.directory()
+
+    def _find_binaries(self, search_directories):
+        binaries = {}
+        for directory in search_directories:
+            for binary in CLANG_BINARIES:
+                path = Path(os.path.join(directory, binary))
+                if not path.exists():
+                    continue
+                path.assert_is_file()
+                path.assert_mode(os.R_OK | os.X_OK)
+                if path.filename() not in binaries:
+                    binaries[path.filename()] = []
+                version = str(ClangVersion(str(path)))
+                binaries[path.filename()].append({'path': str(path),
+                                                  'version': version})
+        return binaries
+
+    def _highest_version(self, versions):
+        return max(versions, key=lambda b: b['version'])
+
+    def best_binaries(self):
+        return {name: self._highest_version(versions) for name, versions in
+                self.binaries.items()}
+
+    def best(self, bin_name):
+        return self.best_binaries()[bin_name]

--- a/framework/clang/format.py
+++ b/framework/clang/format.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import re
+import os
+import sys
+import subprocess
+
+from framework.path.path import Path
+from framework.file.io import read_file, write_file
+
+
+class ClangFormatStyle(object):
+    """
+    Reads and parses a .clang-format style file to represent it. The style can
+    have keys removed and it can be translated into a '--style' argument for
+    invoking clang-format.
+    """
+    def __init__(self, file_path):
+        p = Path(file_path)
+        p.assert_exists()
+        p.assert_is_file()
+        p.assert_mode(os.R_OK)
+        self.file_path = file_path
+        self.raw_contents = read_file(file_path)
+        self.parameters = self._parse_parameters()
+        self.rejected_parameters = {}
+
+    def __str__(self):
+        return self.file_path
+
+    def _parse_parameters(self):
+        # Python does not have a built-in yaml parser, so here is a
+        # hand-written one that *seems* to minimally work for this purpose.
+        many_spaces = re.compile(': +')
+        spaces_removed = many_spaces.sub(':', self.raw_contents)
+        # split into a list of lines
+        lines = [l for l in spaces_removed.split('\n') if l != '']
+        # split by the colon separator
+        split = [l.split(':') for l in lines]
+        # present as a dictionary
+        return {item[0]: ''.join(item[1:]) for item in split}
+
+    def reject_parameter(self, key):
+        if key not in self.rejected_parameters:
+            self.rejected_parameters[key] = self.parameters.pop(key)
+
+    def style_arg(self):
+        return '-style={%s}' % ', '.join(["%s: %s" % (k, v) for k, v in
+                                          self.parameters.items()])
+
+
+class ClangFormat(object):
+    """
+    Facility to read in the formatted content of a file using a particular
+    clang-format binary and style file.
+    """
+    def __init__(self, binary, style_path):
+        self.binary_path = binary['path']
+        self.binary_version = binary['version']
+        self.style_path = style_path
+        self.style = ClangFormatStyle(self.style_path)
+        self.UNKNOWN_KEY_REGEX = re.compile("unknown key '(?P<key_name>\w+)'")
+
+    def _parse_unknown_key(self, err):
+        if len(err) == 0:
+            return 0, None
+        match = self.UNKNOWN_KEY_REGEX.search(err)
+        if not match:
+            return len(err), None
+        return len(err), match.group('key_name')
+
+    def _try_format_file(self, file_path):
+        cmd = [self.binary_path, self.style.style_arg(), file_path]
+        return subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+    def read_formatted_file(self, file_path):
+        while True:
+            p = self._try_format_file(file_path)
+            out = p.stdout.read().decode('utf-8')
+            err = p.stderr.read().decode('utf-8')
+            p.communicate()
+            if p.returncode != 0:
+                sys.exit("*** clang-format could not execute")
+            # Older versions of clang don't support some style parameter keys,
+            # so we work around by redacting any key that gets rejected until
+            # we find a subset of parameters that can apply the format without
+            # producing any stderr output.
+            err_len, unknown_key = self._parse_unknown_key(err)
+            if not unknown_key and err_len > 0:
+                sys.exit("*** clang-format produced unknown output to stderr")
+            if unknown_key:
+                self.style.reject_parameter(unknown_key)
+                continue
+            return out
+
+    def rejected_parameters(self):
+        return self.style.rejected_parameters

--- a/framework/clang/option.py
+++ b/framework/clang/option.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import re
+import os
+import sys
+import argparse
+
+from framework.clang.find import ClangFind, CLANG_BINARIES
+from framework.clang.format import ClangFormat
+from framework.clang.scan_build import ScanBuild
+from framework.clang.scan_view import ScanView
+from framework.build.make import MakeClean
+from framework.path.path import Path
+from framework.argparse.option import add_tmp_directory_option
+from framework.argparse.option import DEFAULT_TMP_DIR
+from framework.file.io import read_file, write_file
+
+
+###############################################################################
+# actions
+###############################################################################
+
+class StyleFileAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, str):
+            sys.exit("*** %s is not a string" % values)
+        self.path = Path(values)
+        self.path.assert_exists()
+        self.path.assert_is_file()
+        self.path.assert_mode(os.R_OK)
+        namespace.style_file = str(self.path)
+
+
+class ClangDirectoryAction(argparse.Action):
+    """
+    Validate that 'values' is a path that points to a directory that has
+    clang executables in it. The set of clang binaries contained is returned
+    along with their detected version. Tolerates either a directory, a
+    directory with a 'bin/' subdirectory or a path to an executable file.
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, str):
+            sys.exit("*** %s is not a string" % values)
+        clang_find = ClangFind(values)
+        executables = clang_find.best_binaries()
+        for clang_binary in CLANG_BINARIES:
+            if clang_binary not in executables:
+                sys.exit("*** %s does not contain a %s binary" %
+                         (values, clang_binary))
+        namespace.clang_executables = executables
+
+
+class ReportPathAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, str):
+            sys.exit("*** %s is not a single string" % values)
+        p = Path(values)
+        p.assert_exists()
+        p.assert_is_directory()
+        p.assert_mode(os.R_OK | os.W_OK)
+
+
+###############################################################################
+# defaults
+###############################################################################
+
+SCAN_BUILD_OUTPUT = "scan_build.log"
+MAKE_CLEAN_OUTPUT = "make_clean.log"
+SCAN_BUILD_REPORT_DIR = 'scan-build'
+
+###############################################################################
+# add options
+###############################################################################
+
+
+def add_clang_bin_path_option(parser):
+    b_help = ("path to the clang directory or binary to be used "
+              "(default=The required clang binary installed in PATH with the "
+              "highest version number)")
+    parser.add_argument("-b", "--bin-path", type=str,
+                        action=ClangDirectoryAction, help=b_help)
+
+
+def add_clang_format_style_file_option(parser):
+    sf_help = ("path to the clang style file to be used (default=The "
+               "src/.clang_format file specified in the repo info)")
+    parser.add_argument("-s", "--style-file", type=str, action=StyleFileAction,
+                        help=sf_help)
+
+
+def add_clang_format_force_option(parser):
+    f_help = ("force proceeding with if clang-format doesn't support all "
+              "parameters in the style file (default=False)")
+    parser.add_argument("-f", "--force", action='store_true', help=f_help)
+
+
+def add_clang_options(parser, report_path=False, style_file=False,
+                      force=False):
+    """
+    Adds optional arguments to the parser for specifying options for
+    clang binaries and their execution settings.
+    """
+    add_clang_bin_path_option(parser)
+    if report_path:
+        add_tmp_directory_option(parser)
+    if style_file:
+        add_clang_format_style_file_option(parser)
+    if force:
+        add_clang_format_force_option(parser)
+
+
+###############################################################################
+# finish settings
+###############################################################################
+
+def finish_clang_settings(settings):
+    """
+    Makes the settings namepsce uniform by instantiating classes filled in with
+    default behavior if settings have not been specified by the user.
+    """
+    assert hasattr(settings, 'repository')
+    if not hasattr(settings, 'jobs'):
+        settings.jobs = 1
+    # locate clang executables:
+    if hasattr(settings, 'clang_executables'):
+        clang_format = settings.clang_executables['clang-format']
+        scan_build = settings.clang_executables['scan-build']
+        scan_view = settings.clang_executables['scan-view']
+    else:
+        finder = ClangFind()
+        clang_format = finder.best('clang-format')
+        scan_build = finder.best('scan-build')
+        scan_view = finder.best('scan-view')
+    # clang-format settings:
+    json_style = settings.repository.repo_info['clang_format_style']['value']
+    default_style = os.path.join(str(settings.repository), json_style)
+    clang_format_style_path = (settings.style_file if
+                               (hasattr(settings, 'style_file') and
+                                settings.style_file) else default_style)
+    settings.clang_format = ClangFormat(clang_format,
+                                        clang_format_style_path)
+    # scan-build settings:
+    viewer = ScanView(scan_view)
+    settings.tmp_directory = (settings.tmp_directory if
+                              hasattr(settings, "tmp_directory") else
+                              DEFAULT_TMP_DIR)
+    make_clean_output_file = os.path.join(settings.tmp_directory,
+                                          MAKE_CLEAN_OUTPUT)
+    cleaner = MakeClean(str(settings.repository), make_clean_output_file)
+    scan_build_output_file = os.path.join(settings.tmp_directory,
+                                          SCAN_BUILD_OUTPUT)
+    scan_build_report_dir = os.path.join(settings.tmp_directory,
+                                         SCAN_BUILD_REPORT_DIR)
+    settings.scan_build = ScanBuild(scan_build, scan_build_report_dir,
+                                    cleaner, viewer, str(settings.repository),
+                                    scan_build_output_file, settings.jobs)

--- a/framework/clang/scan_build.py
+++ b/framework/clang/scan_build.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import subprocess
+import plistlib
+import itertools
+
+from framework.path.path import Path
+from framework.build.make import Make
+
+
+class ScanBuildPlistDirectory(Path):
+    """
+    Represents the directory created by scan-build to hold the output
+    plist files. Parses the plist files to reveal discovered issues.
+    """
+    def __init__(self, directory):
+        path = Path(directory)
+        path.assert_exists()
+        path.assert_is_directory()
+        path.assert_mode(os.R_OK)
+        self.directory = directory
+
+    def _find_events(self, paths, files):
+        for p in paths:
+            if p['kind'] == 'event':
+                yield {'message': p['extended_message'],
+                       'line':    p['location']['line'],
+                       'col':     p['location']['col'],
+                       'file':    files[p['location']['file']]}
+
+    def _plist_to_issue(self, plist):
+        files = plist['files']
+        for d in plist['diagnostics']:
+            yield {'type':        d['type'],
+                   'description': d['description'],
+                   'line':        d['location']['line'],
+                   'col':         d['location']['col'],
+                   'file':        files[d['location']['file']],
+                   'events':      list(self._find_events(d['path'], files))}
+
+    def issues(self):
+        plist_files = (os.path.join(self.directory, f) for f in
+                       os.listdir(self.directory) if f.endswith('.plist'))
+        read_plists = (plistlib.readPlist(plist_file) for plist_file in
+                       plist_files)
+        relevant_plists = (plist for plist in read_plists if
+                           len(plist['diagnostics']) > 0)
+        return list(itertools.chain(*[self._plist_to_issue(plist) for plist in
+                                    relevant_plists]))
+
+
+class ScanBuildReportDirectory(Path):
+    """
+    Represents the directory that is given to scan-build for it to create
+    a directory containing the results from the run.
+    """
+    def __init__(self, directory):
+        if not os.path.exists(str(directory)):
+            os.makedirs(str(directory))
+        path = Path(directory)
+        path.assert_mode(os.R_OK | os.W_OK)
+        self.directory = directory
+
+    def __str__(self):
+        return str(self.directory)
+
+    def most_recent_results(self):
+        # scan-build puts results in a subdirectory where the directory name is
+        # a timestamp. e.g. /tmp/bitcoin-scan-build/2017-01-23-115243-901-1 We
+        # want the most recent directory, so we sort and return the path name
+        # sorted highest.
+        subdirs = sorted([d for d in os.listdir(self.directory) if
+                          os.path.isdir(os.path.join(self.directory, d))])
+        directory = ScanBuildPlistDirectory(os.path.join(self.directory,
+                                                         subdirs[-1]))
+        return directory.directory, directory.issues()
+
+
+class ScanBuild(Make):
+    """
+    Executes 'make' wrapped in scan-build to get static analysis results.
+    """
+    def __init__(self, binary, report_dir, cleaner, viewer, repository,
+                 output_file, jobs):
+        super().__init__(repository, output_file, jobs)
+        self.binary_path = binary['path']
+        self.binary_version = binary['version']
+        self.report_dir = ScanBuildReportDirectory(report_dir)
+        self.options_str = ('-k -plist-html --keep-empty -o %s' %
+                            str(self.report_dir))
+        self.cleaner = cleaner
+        self.viewer = viewer
+
+    def _cmd(self):
+        return "%s %s %s" % (self.binary_path, self.options_str,
+                             super()._cmd())
+
+    def get_results(self):
+        return self.report_dir.most_recent_results()

--- a/framework/clang/scan_view.py
+++ b/framework/clang/scan_view.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from framework.print.buffer import PrintBuffer
+
+
+class ScanView(object):
+    """
+    Encapsulates clang's 'scan-view' utility which displays 'scan-build'
+    results nicely in a broswer.
+    """
+    def __init__(self, binary):
+        self.binary_path = binary['path']
+        self.binary_version = binary['version']
+
+    def launch_instructions(self, result_dir):
+        b = PrintBuffer()
+        b.separator()
+        b.add("Full details can be seen in a browser by running:\n")
+        b.add("    $ %s %s\n" % (self.binary_path, result_dir))
+        b.separator()
+        return str(b)

--- a/framework/clang/setup.py
+++ b/framework/clang/setup.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import subprocess
+import shutil
+
+from framework.file.io import write_file
+from framework.clang.download import ClangDownload
+
+CLANG_DIR = "clang-release-dl"
+TEST_STYLE_FILE_NAME = ".alternate-clang-format"
+TEST_STYLE_FILE_CONTENT = """
+Language:        Cpp
+AccessModifierOffset: -4
+AlignEscapedNewlinesLeft: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackParameters: false
+BreakBeforeBinaryOperators: false
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, BOOST_REVERSE_FOREACH ]
+IndentCaseLabels: false
+IndentFunctionDeclarationAfterType: false
+IndentWidth:     4
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: None
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+Standard:        Cpp03
+TabWidth:        8
+UseTab:          Never
+"""
+
+
+def clang_setup_test_style_file(directory):
+    clang_dir = os.path.join(directory, CLANG_DIR)
+    style_file = os.path.join(clang_dir, TEST_STYLE_FILE_NAME)
+    write_file(style_file, TEST_STYLE_FILE_CONTENT)
+    return style_file
+
+
+def clang_setup_bin_dir(directory):
+    clang_dir = os.path.join(directory, CLANG_DIR)
+    if not os.path.exists(str(clang_dir)):
+        os.makedirs(str(clang_dir))
+    downloader = ClangDownload(clang_dir)
+    downloader.download()
+    downloader.verify()
+    return downloader.unpack()

--- a/framework/clang/tarball.py
+++ b/framework/clang/tarball.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import platform
+
+
+class ClangTarball(object):
+    """
+    Matches the current platform to the LLVM download. Only works for platforms
+    that have been explicitly tested but it should be straightforward to add
+    more as needed.
+    """
+    def __init__(self):
+        self.supported = self._supported()
+
+    def _supported_debian(self, version):
+        return version.startswith("8.")
+
+    def _supported_ubuntu(self, id):
+        return id in ['trusty', 'xenial']
+
+    def _supported(self):
+        if platform.system() != "Linux":
+            print(platform.system())
+            return False
+        if platform.machine() != "x86_64":
+            return False
+        self.distname, self.version, self.id = platform.linux_distribution()
+        if self.distname not in ['debian', 'Ubuntu']:
+            return False
+        if self.distname == 'debian':
+            return self._supported_debian(self.version)
+        else:
+            return self._supported_ubuntu(self.id)
+
+    def url(self):
+        if not self.supported:
+            return None
+        return "http://releases.llvm.org/3.9.0/%s" % self.filename()
+
+    def filename(self):
+        if not self.supported:
+            return None
+        return ("%s.tar.xz" % self.unpacked_directory())
+
+    def unpacked_directory(self):
+        if not self.supported:
+            return None
+        if self.distname == 'debian':
+            return "clang+llvm-3.9.0-x86_64-linux-gnu-debian8"
+        else:
+            if self.id == 'trusty':
+                return "clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-14.04"
+            else:
+                return "clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04"
+
+    def sha256(self):
+        if not self.supported:
+            return None
+        if self.distname == 'debian':
+            return ("916e2c2c1411e7e568e856e614408a8072c1884339865e8cfabc71880"
+                    "f28a804")
+        else:
+            if self.id == 'trusty':
+                return ("6eba6f834424086a40ca95e7b013765d8bcbfdce193b5ab7da42e"
+                        "2ff5beadf3e")
+            else:
+                return ("e189a9e605ec035bfa1cfebf37374a92109b61291dc17c6f71239"
+                        "8ecccb3498a")

--- a/framework/cmd/file_content.py
+++ b/framework/cmd/file_content.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import time
+import json
+import sys
+from framework.print.buffer import PrintBuffer
+from framework.file.filter import FileFilter
+from framework.file.info import FileInfos
+from framework.cmd.repository import RepositoryCmd
+
+
+class FileContentCmd(RepositoryCmd):
+    """
+    Base class for commands that compute info on a set of files based on
+    the content inside of the files. Provides a common way for indicating
+    a subset of files that the operation is to apply to via lists of
+    fnmatch expressions.
+    """
+    def __init__(self, settings):
+        assert hasattr(settings, 'json')
+        super().__init__(settings, silent=settings.json)
+        assert hasattr(settings, 'jobs')
+        assert hasattr(settings, 'include_fnmatches')
+        assert hasattr(settings, 'target_fnmatches')
+        self.title = "FileContentCmd superclass"
+        self.json = settings.json
+        self.jobs = settings.jobs
+        self.tracked_files = self.repository.tracked_files()
+        exclude_fnmatches = self.repository.repo_info['subtrees']['fnmatches']
+        self.files_in_scope = list(
+            self._files_in_scope(self.repository, self.tracked_files,
+                                 settings.include_fnmatches,
+                                 exclude_fnmatches))
+        self.files_targeted = list(
+            self._files_targeted(self.repository, self.files_in_scope,
+                                 settings.include_fnmatches, exclude_fnmatches,
+                                 settings.target_fnmatches))
+
+    def _scope_filter(self, repository, include_fnmatches, exclude_fnmatches):
+        file_filter = FileFilter()
+        file_filter.append_include(include_fnmatches,
+                                   base_path=str(repository))
+        file_filter.append_exclude(exclude_fnmatches,
+                                   base_path=str(repository))
+        return file_filter
+
+    def _files_in_scope(self, repository, tracked_files, include_fnmatches,
+                        exclude_fnmatches):
+        file_filter = self._scope_filter(repository, include_fnmatches,
+                                         exclude_fnmatches)
+        return (f for f in tracked_files if file_filter.evaluate(f))
+
+    def _target_filter(self, repository, include_fnmatches, exclude_fnmatches,
+                       target_fnmatches):
+        file_filter = self._scope_filter(repository, include_fnmatches,
+                                         exclude_fnmatches)
+        file_filter.append_include(target_fnmatches, base_path=repository)
+        return file_filter
+
+    def _files_targeted(self, repository, tracked_files, include_fnmatches,
+                        exclude_fnmatches, target_fnmatches):
+        file_filter = self._target_filter(repository, include_fnmatches,
+                                          exclude_fnmatches, target_fnmatches)
+        return (f for f in tracked_files if file_filter.evaluate(f))
+
+    def _read_file_infos(self):
+        self.file_infos.read_all()
+
+    def _compute_file_infos(self):
+        self.file_infos.compute_all()
+
+    def _read_and_compute_file_infos(self):
+        start_time = time.time()
+        self.file_infos = FileInfos(self.jobs, self._file_info_list())
+        self._read_file_infos()
+        self._compute_file_infos()
+        self.elapsed_time = time.time() - start_time
+
+    def _exec(self):
+        self._read_and_compute_file_infos()
+        r = super()._exec()
+        r['tracked_files'] = len(self.tracked_files)
+        r['files_in_scope'] = len(self.files_in_scope)
+        r['files_targeted'] = len(self.files_targeted)
+        r['jobs'] = self.jobs
+        return r
+
+    def _output(self, results):
+        if self.json:
+            return super()._output(results)
+        b = PrintBuffer()
+        r = results
+        b.separator()
+        b.add("%4d files tracked in repo\n" % r['tracked_files'])
+        b.add("%4d files in scope according to .bitcoin_maintainer_tools.json "
+              "settings\n" % r['files_in_scope'])
+        b.add("%4d files examined according to listed targets\n" %
+              r['files_targeted'])
+        b.add("%4d parallel jobs for computing analysis\n" % r['jobs'])
+        b.separator()
+        return str(b)
+
+    def _shell_exit(self, results):
+        return 0

--- a/framework/cmd/repository.py
+++ b/framework/cmd/repository.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import json
+
+
+class RepositoryCmd(object):
+    """
+    Superclass for a command or subcommand that is targeted at a git
+    repository. 'silent=True' instructs to only print what is produced by the
+    _output() function.
+    """
+    def __init__(self, settings, silent=False):
+        assert hasattr(settings, 'repository')
+        self.settings = settings
+        self.repository = settings.repository
+        self.silent = silent
+        self.title = "RepositoryCmd superclass"
+
+    def _exec(self):
+        return {}
+
+    def _output(self, results):
+        return json.dumps(results)
+
+    def _shell_exit(self, results):
+        return 0
+
+    def _print(self, output, exit):
+        if output:
+            print(output)
+        if self.silent and type(exit) is str:
+            sys.exit(1)
+        sys.exit(exit)
+
+    def run(self):
+        results = self._exec()
+        self._print(self._output(results), self._shell_exit(results))
+
+
+class RepositoryCmds(RepositoryCmd):
+    """
+    Superclass for aggregating several RepositoryCmd instances together for
+    a single invocation. The individual instances are passed in as a
+    dictionary.
+    """
+    def __init__(self, settings, repository_cmds, silent=False):
+        super().__init__(settings, silent=silent)
+        assert type(repository_cmds) is dict
+        for k, v in repository_cmds.items():
+            assert type(k) is str
+            assert issubclass(type(v), RepositoryCmd)
+        self.repository_cmds = repository_cmds
+        self.title = "RepositoryCmds superclass"
+
+    def _exec(self):
+        results = super()._exec()
+        for key, cmd in sorted(self.repository_cmds.items()):
+            if not self.silent:
+                print("Computing analysis of '%s'..." % cmd.title)
+            results[key] = cmd._exec()
+            if not self.silent:
+                print("Done.")
+        if not self.silent:
+            print("")
+        return results
+
+    def _shell_exit(self, results):
+        exits = [r._shell_exit(results[l]) for l, r in
+                 sorted(self.repository_cmds.items())]
+        if all(e == 0 for e in exits):
+            return 0
+        non_zero_ints = [e for e in exits if type(e) is int and not e == 0]
+        strings = [e for e in exits if type(e) is str]
+        if len(strings) == 0:
+            return max(non_zero_ints)
+        return '\n'.join(strings)

--- a/framework/file/filter.py
+++ b/framework/file/filter.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import re
+import os
+import fnmatch
+
+
+class FileFilter(object):
+    """
+    Wraps and utilizes regular expression to quickly evaluate whether a path
+    is included or excluded from a desired set of files. The desired set of
+    files to include or exclude is indicated by appending a list of fnmatch
+    expressions. The expressions are evaluated is the order that they are
+    added.
+    """
+    def __init__(self):
+        self.layers = []
+
+    def _append(self, layer_type, regex):
+        self.layers.append({'layer_type': layer_type,
+                            'regex':      regex})
+
+    def _compile(self, fnmatches, base_path):
+        if base_path:
+            fnmatches = [os.path.join(base_path, f) for f in fnmatches]
+        return re.compile('|'.join([fnmatch.translate(f) for f in fnmatches]))
+
+    def append_include(self, fnmatches, base_path=None):
+        if len(fnmatches) == 0:
+            return
+        self._append('include', self._compile(fnmatches, base_path))
+
+    def append_exclude(self, fnmatches, base_path=None):
+        if len(fnmatches) == 0:
+            return
+        self._append('exclude', self._compile(fnmatches, base_path))
+
+    def _matches_regex(self, path, regex):
+        return regex.match(path) is not None
+
+    def _evaluate_layers(self, path):
+        for layer in self.layers:
+            if layer['layer_type'] is 'include':
+                yield self._matches_regex(path, layer['regex'])
+            if layer['layer_type'] is 'exclude':
+                yield not self._matches_regex(path, layer['regex'])
+
+    def evaluate(self, path):
+        return False not in self._evaluate_layers(path)

--- a/framework/file/hash.py
+++ b/framework/file/hash.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import hashlib
+
+BUF_SIZE = 65536
+
+
+class FileHash(object):
+    """
+    Calculates and represents the SHA256 hash of the contents of the file
+    """
+    def __init__(self, file_path):
+        self.sha256 = hashlib.sha256()
+        f = open(file_path, 'rb')
+        while True:
+            data = f.read(BUF_SIZE)
+            if not data:
+                break
+            self.sha256.update(data)
+
+    def __str__(self):
+        return self.sha256.hexdigest()

--- a/framework/file/info.py
+++ b/framework/file/info.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import os
+from multiprocessing import Pool
+
+from framework.file.io import read_file, write_file
+
+
+class FileInfo(dict):
+    """
+    Superclass to represent a file, its contents, and computed information
+    about the file.
+    """
+    def __init__(self, repository, file_path):
+        super().__init__()
+        self['repository'] = repository
+        self['file_path'] = file_path
+        self['filename'] = file_path.split(str(repository))[1]
+
+    def read(self):
+        self['content'] = read_file(self['file_path'])
+
+    def compute(self):
+        sys.exit("*** 'compute' function must be redefined by subclass")
+
+    def set_write_content(self, write_content):
+        self['write_content'] = write_content
+
+    def write(self):
+        if self['content'] == self['write_content']:
+            return
+        write_file(self['file_path'], self['write_content'])
+
+
+def compute_file_info(file_info):
+    file_info.compute()
+    return file_info
+
+
+class FileInfos(object):
+    """
+    A container for a set of files which can do the computing of the file info
+    in parallel. I/O is done in serial because some VM setups can't gracefully
+    schedule parallel, high-throughput file system I/O.
+    """
+    def __init__(self, jobs, file_info_iter):
+        self.jobs = jobs
+        self.pool = Pool(jobs)
+        self.file_info_list = list(file_info_iter)
+
+    def __iter__(self):
+        for file_info in self.file_info_list:
+            yield file_info
+
+    def read_all(self):
+        for file_info in self.file_info_list:
+            file_info.read()
+
+    def write_all(self):
+        for file_info in self.file_info_list:
+            file_info.write()
+
+    def compute_all(self):
+        self.file_info_list = self.pool.map(compute_file_info, self)

--- a/framework/file/io.py
+++ b/framework/file/io.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+def read_file(file_path):
+    file = open(file_path, 'r')
+    content = file.read()
+    file.close()
+    return content
+
+
+def write_file(file_path, content):
+    file = open(file_path, 'w')
+    file.write(content)
+    file.close()

--- a/framework/file/style.py
+++ b/framework/file/style.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import difflib
+import time
+
+
+class FileStyleScore(object):
+    """
+    A crude calculation to give a percentage rating for adherence to a
+    defined style.
+    """
+    def __init__(self, lines_before, lines_added, lines_removed,
+                 lines_unchanged, lines_after):
+        self.lines_before = lines_before
+        self.lines_unchanged = lines_unchanged
+        self.lines_added = lines_added
+        self.lines_removed = lines_removed
+        self.lines_after = lines_after
+        self.score = (100.0 if (lines_added + lines_removed) == 0 else
+                      min(abs(1.0 - (float(lines_before - lines_unchanged) /
+                                     float(lines_before))) * 100, 99.999))
+
+    def __str__(self):
+        return (" +--------+         +------------+--------+---------+--------"
+                "---+------------+\n"
+                " | score  |         |     before |  added | removed | unchang"
+                "ed |      after |\n"
+                " +--------+ +-------+------------+--------+---------+--------"
+                "---+------------+\n"
+                " | %3.2f%% | | lines | %10d | %6d | %7d | %9d | %10d |\n"
+                " +--------+ +-------+------------+--------+---------+--------"
+                "---+------------+\n" % (self.score, self.lines_before,
+                                         self.lines_added, self.lines_removed,
+                                         self.lines_unchanged,
+                                         self.lines_after))
+
+    def __float__(self):
+        return self.score
+
+    def in_range(self, lower, upper):
+        # inclusive:
+        return (self.score >= lower) and (self.score <= upper)
+
+
+DIFFER = difflib.Differ()
+
+
+class FileStyleDiff(dict):
+    """
+    Computes metrics about a diff between two versions of content in a file.
+    """
+    def __init__(self, contents_before, contents_after):
+        super().__init__()
+        lines_before = contents_before.splitlines()
+        lines_after = contents_after.splitlines()
+        self['lines_before'] = len(lines_before)
+        self['lines_after'] = len(lines_after)
+        start_time = time.time()
+        diff = DIFFER.compare(lines_before, lines_after)
+        (self['lines_added'],
+         self['lines_removed'],
+         self['lines_unchanged']) = self._sum_lines_of_type(diff)
+        self['score'] = FileStyleScore(self['lines_before'],
+                                       self['lines_added'],
+                                       self['lines_removed'],
+                                       self['lines_unchanged'],
+                                       self['lines_after'])
+        self['diff_time'] = time.time() - start_time
+
+    def _sum_lines_of_type(self, diff):
+        def classify_diff_lines(diff):
+            for l in diff:
+                if l.startswith('+ '):
+                    yield 1, 0, 0
+                elif l.startswith('- '):
+                    yield 0, 1, 0
+                elif l.startswith('  '):
+                    yield 0, 0, 1
+
+        sums = [sum(c) for c in zip(*classify_diff_lines(diff))]
+        return (sums[0], sums[1], sums[2]) if len(sums) == 3 else (0, 0, 0)

--- a/framework/git/clone.py
+++ b/framework/git/clone.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+
+from framework.git.repository import GitRepository
+from framework.path.path import Path
+
+
+class GitClone(object):
+    def __init__(self, upstream_url, silent=False):
+        self.upstream_url = upstream_url
+        self.silent = silent
+
+    def clone(self, repository_base):
+        cmd = "git clone %s %s" % (self.upstream_url, repository_base)
+        outfile = open(os.devnull, 'w') if self.silent else None
+        rc = subprocess.call(cmd.split(" "), stdout=outfile, stderr=outfile)
+        if rc != 0:
+            sys.exit("*** clone command '%s' failed" % cmd)
+        return GitRepository(repository_base)
+
+    def _fetch(self, repository_base):
+        r = GitRepository(repository_base)
+        r.fetch()
+        return r
+
+    def clone_or_fetch(self, repository_base):
+        """
+        Clones a fresh repository at the given base unless it exists already.
+        If it exists already, it will fetch the latest upstream state (which is
+        less abusive of the github servers than a full clone). The result will
+        be returned as a GitRepository instance.
+        """
+        p = Path(repository_base)
+        return (self._fetch(repository_base) if p.exists() else
+                self.clone(repository_base))

--- a/framework/git/parameter.py
+++ b/framework/git/parameter.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import argparse
+
+from framework.git.repository import GitPath
+from framework.git.repository import GitRepository
+
+
+###############################################################################
+# actions
+###############################################################################
+
+class GitRepositoryAction(argparse.Action):
+    """
+    Checks that the string points to a valid git repository.
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, str):
+            sys.exit("*** %s is not a string" % values)
+        repository = GitRepository(values)
+        repository.assert_has_makefile()
+        namespace.repository = repository
+        namespace.target_fnmatches = [os.path.join(str(repository), '*')]
+
+
+class GitTrackedTargetsAction(argparse.Action):
+    """
+    Validate that 'values' is a list of strings that all represent files or
+    directories under a git repository path.
+    """
+    def _check_values(self, values):
+        if not isinstance(values, list):
+            sys.exit("*** %s is not a list" % values)
+        types = [type(value) for value in values]
+        if len(set(types)) != 1:
+            sys.exit("*** %s has multiple object types" % values)
+        if not isinstance(values[0], str):
+            sys.exit("*** %s does not contain strings" % values)
+
+    def _get_targets(self, values):
+        targets = [GitPath(value) for value in values]
+        for target in targets:
+            target.assert_exists()
+            target.assert_mode(os.R_OK)
+        return targets
+
+    def _get_common_repository(self, targets):
+        repositories = [str(target.repository_base()) for target in targets]
+        if len(set(repositories)) > 1:
+            sys.exit("*** targets from multiple repositories %s" %
+                     set(repositories))
+        for target in targets:
+            target.assert_under_directory(repositories[0])
+        return GitRepository(repositories[0])
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        self._check_values(values)
+        targets = self._get_targets(values)
+        namespace.repository = self._get_common_repository(targets)
+
+        target_files = [os.path.join(str(namespace.repository), str(t)) for t
+                        in targets if t.is_file()]
+        target_directories = [os.path.join(str(namespace.repository), str(t))
+                              for t in targets if t.is_directory()]
+        namespace.target_fnmatches = (target_files +
+                                      [os.path.join(d, '*') for d in
+                                       target_directories])
+
+
+###############################################################################
+# add args
+###############################################################################
+
+
+def add_git_repository_parameter(parser):
+    repo_help = ("A source code repository for which the operation is to be "
+                 "performed upon.")
+    parser.add_argument("repository", type=str, action=GitRepositoryAction,
+                        nargs='?', default='.', help=repo_help)
+
+
+def add_git_tracked_targets_parameter(parser):
+    t_help = ("A list of files and/or directories that select the subset of "
+              "files for this action. If a directory is given as a target, "
+              "all files contained in it and its subdirectories are "
+              "recursively selected. All targets must be tracked in the same "
+              "git repository clone. (default=The current directory)")
+    parser.add_argument("target", type=str, action=GitTrackedTargetsAction,
+                        nargs='*', default=['.'], help=t_help)

--- a/framework/git/path.py
+++ b/framework/git/path.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+
+from framework.path.path import Path
+
+
+class GitPath(Path):
+    """
+    A Path that has some additional functions for awareness of the git
+    repository that holds the path.
+    """
+    def _in_git_repository(self):
+        cmd = 'git -C %s status' % self.directory()
+        dn = open(os.devnull, 'w')
+        return subprocess.call(cmd.split(' '), stderr=dn, stdout=dn) == 0
+
+    def assert_in_git_repository(self):
+        if not self._in_git_repository():
+            sys.exit("*** %s is not inside a git repository" % self)
+
+    def _is_repository_base(self):
+        self.assert_is_directory()
+        return Path(os.path.join(self.path, '.git/')).exists()
+
+    def repository_base(self):
+        directory = GitPath(self.directory())
+        if directory._is_repository_base():
+            return directory
+
+        def recurse_repo_base_dir(git_path_arg):
+            git_path_arg.assert_in_git_repository()
+            d = GitPath(git_path_arg.containing_directory())
+            if str(d) is '/':
+                sys.exit("*** did not find underlying repo?")
+            if d._is_repository_base():
+                return d
+            return recurse_repo_base_dir(d)
+
+        return recurse_repo_base_dir(self)
+
+
+GIT_LOG_CMD = "git log --follow --pretty=format:%%ai %s"
+
+
+class GitFilePath(GitPath):
+    """
+    A GitPath for a particular file where additional specific information
+    can be queried
+    """
+    def __init__(self, path):
+        super().__init__(path)
+        self.assert_is_file()
+        self.assert_in_git_repository()
+        self.repository = str(self.repository_base())
+
+    def _git_log(self):
+        cmd = (GIT_LOG_CMD % self).split(' ')
+        orig = os.getcwd()
+        os.chdir(self.repository)
+        out = subprocess.check_output(cmd)
+        os.chdir(orig)
+        decoded = out.decode("utf-8")
+        if decoded == '':
+            return []
+        return decoded.split('\n')
+
+    def _git_change_years(self):
+        git_log_lines = self._git_log()
+        # timestamp is in ISO 8601 format. e.g. "2016-09-05 14:25:32 -0600"
+        return [line.split(' ')[0].split('-')[0] for line in git_log_lines]
+
+    def year_of_most_recent_change(self):
+        return max(self._git_change_years())
+
+    def change_year_range(self):
+        years = self._git_change_years()
+        return min(years), max(years)

--- a/framework/git/repository.py
+++ b/framework/git/repository.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import subprocess
+import argparse
+
+from framework.path.path import Path
+from framework.repository.info import RepositoryInfo
+from framework.git.path import GitPath
+
+
+LS_TRACKED = "git ls-files"
+CHECK_UNTRACKED_UNIGNORED = "git ls-files --exclude-standard --others"
+CHECK_CHANGES = "git diff-index --quiet HEAD"
+RESET_HARD = "git reset --hard %s"
+FETCH = "git fetch"
+
+
+class GitRepository(object):
+    """
+    Represents queries information, and performs actions on a git repository
+    clone.
+    """
+    def __init__(self, repository_base):
+        self.repository_base = str(Path(repository_base))
+        git_path = GitPath(repository_base)
+        git_path.assert_exists()
+        git_path.assert_mode(os.R_OK)
+        git_path.assert_in_git_repository()
+        if str(self.repository_base) != str(git_path.repository_base()):
+            sys.exit("*** %s is not the base of its repository" %
+                     self.repository_base)
+        self.repo_info = RepositoryInfo(self.repository_base)
+
+    def __str__(self):
+        return self.repository_base
+
+    def tracked_files(self):
+        orig = os.getcwd()
+        os.chdir(self.repository_base)
+        out = subprocess.check_output(LS_TRACKED.split(" "))
+        os.chdir(orig)
+        return [os.path.join(self.repository_base, f) for f in
+                out.decode("utf-8").split('\n') if f != '']
+
+    def assert_has_makefile(self):
+        makefile = Path(os.path.join(self.repository_base, "Makefile"))
+        if not makefile.exists():
+            sys.exit("*** no Makefile found in %s. You must ./autogen.sh "
+                     "and/or ./configure first" % self.repository_base)
+
+    def _has_changes(self):
+        orig = os.getcwd()
+        os.chdir(self.repository_base)
+        rc = subprocess.call(CHECK_CHANGES.split(" "))
+        os.chdir(orig)
+        return rc != 0
+
+    def _has_untracked_or_unignored(self):
+        orig = os.getcwd()
+        os.chdir(self.repository_base)
+        out = subprocess.check_output(CHECK_UNTRACKED_UNIGNORED.split(" "))
+        os.chdir(orig)
+        return out.decode("utf-8") != ""
+
+    def _is_dirty(self):
+        return self._has_changes() or self._has_untracked_or_unignored()
+
+    def assert_not_dirty(self):
+        if self._is_dirty():
+            sys.exit("*** repository has uncommitted changes.")
+
+    def assert_dirty(self):
+        if not self._is_dirty():
+            sys.exit("*** repository has no uncommitted changes.")
+
+    def reset_hard(self, branch):
+        orig = os.getcwd()
+        os.chdir(self.repository_base)
+        cmd = RESET_HARD % branch
+        out = subprocess.check_output(cmd.split(" "))
+        os.chdir(orig)
+
+    def reset_hard_head(self):
+        self.reset_hard('HEAD')
+
+    def fetch(self, silent=False):
+        orig = os.getcwd()
+        os.chdir(self.repository_base)
+        outfile = open(os.devnull, 'w') if silent else None
+        rc = subprocess.call(FETCH.split(" "), stdout=outfile, stderr=outfile)
+        os.chdir(orig)

--- a/framework/path/path.py
+++ b/framework/path/path.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import os
+
+
+class Path(object):
+    """
+    Base class for representing and validating command-line arguments that
+    are strings but are supposed to be a file system path with particular
+    properties.
+    """
+    def __init__(self, path):
+        self.path = self._get_real_path(str(path))
+
+    def __str__(self):
+        return self.path
+
+    def _get_real_path(self, path):
+        return os.path.realpath(os.path.abspath(path))
+
+    def exists(self):
+        return os.path.exists(self.path)
+
+    def assert_exists(self):
+        if not self.exists():
+            sys.exit("*** does not exist: %s" % self.path)
+
+    def assert_mode(self, flags):
+        if not os.access(self.path, flags):
+            sys.exit("*** %s does not have mode: %x" % (self.path, flags))
+
+    def is_file(self):
+        return os.path.isfile(self.path)
+
+    def assert_is_file(self):
+        if not self.is_file():
+            sys.exit("*** %s is not a file" % self.path)
+
+    def is_directory(self):
+        return os.path.isdir(self.path)
+
+    def assert_is_directory(self):
+        if not self.is_directory():
+            sys.exit("*** %s is not a directory" % self.path)
+
+    def assert_under_directory(self, directory):
+        real_directory = self._get_real_path(directory)
+        if not self.path.startswith(real_directory):
+            sys.exit("*** %s is not under directory %s" % (self.path,
+                                                           real_directory))
+
+    def filename(self):
+        self.assert_is_file()
+        return os.path.basename(self.path)
+
+    def has_filename(self, filename):
+        return filename == self.filename()
+
+    def assert_has_filename(self, filename):
+        if not self.has_filename(filename):
+            sys.exit("*** %s does not have filename %s" % (self.path,
+                                                           filename))
+
+    def containing_directory(self):
+        return os.path.dirname(self.path)
+
+    def directory(self):
+        return self.containing_directory() if self.is_file() else self.path
+
+    def extension(self):
+        _, ext = os.path.splitext(self.filename())
+        return ext
+
+    def extension_is_one_of(self, extensions):
+        return self.extension() in extensions
+
+    def assert_extension_is_one_of(self, extensions):
+        if not self.extension_is_one_of(extensions):
+            sys.exit("*** %s does not have extension %s" % (self.path,
+                                                            extensions))

--- a/framework/print/buffer.py
+++ b/framework/print/buffer.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+GREEN = '\033[92m'
+RED = '\033[91m'
+ENDC = '\033[0m'
+
+
+class PrintBuffer(object):
+    '''
+    A class for appending to a string without printing it yet. Also provides
+    a few amenities for constructing report output.
+    '''
+    def __init__(self):
+        self.report = []
+
+    def __str__(self):
+        return ''.join(self.report)
+
+    def add(self, string):
+        self.report.append(string)
+
+    def add_red(self, string):
+        self.add(RED + string + ENDC)
+
+    def add_green(self, string):
+        self.add(GREEN + string + ENDC)
+
+    def separator(self):
+        self.add('-' * 80 + '\n')
+
+    def flush(self):
+        print(str(self), end='')
+        self.report = []

--- a/framework/repository/info.py
+++ b/framework/repository/info.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import json
+import os
+import sys
+
+from framework.path.path import Path
+from framework.file.io import read_file
+from framework.git.path import GitPath
+
+REPO_INFO_FILENAME = ".bitcoin-maintainer-tools.json"
+FAILBACK_REPO_INFO_FILENAME = ".fallback-bitcoin-maintainer-tools.json"
+
+
+class RepositoryInfo(dict):
+    """
+    Dictionary that is sourced from a json file in the target repository.
+    If the file doesn't exist, a fallback file is used for the settings.
+    """
+    def __init__(self, repository_base):
+        super().__init__()
+        json_file = os.path.join(repository_base, REPO_INFO_FILENAME)
+        path = Path(json_file)
+        if not path.exists():
+            # If there is no .json file in the repo, it might be an old version
+            # checked out. We can still do best-effort with a default file
+            # that is located in this repo.
+            json_file = self._failback_file()
+            path = Path(json_file)
+            if not path.exists():
+                sys.exit("Could not find a .json repository info file to use.")
+        path.assert_is_file()
+        path.assert_mode(os.R_OK)
+        content = read_file(json_file)
+        self.update(json.loads(content))
+
+    def _failback_file(self):
+        gp = GitPath(os.path.abspath(os.path.realpath(__file__)))
+        return os.path.join(str(gp.repository_base()),
+                            FAILBACK_REPO_INFO_FILENAME)

--- a/framework/test/cmd.py
+++ b/framework/test/cmd.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import time
+import json
+import subprocess
+import argparse
+
+from framework.print.buffer import PrintBuffer
+from framework.cmd.repository import RepositoryCmd
+
+
+class ScriptTestCmd(RepositoryCmd):
+    """
+    Superclass for structuring a command that invokes a script in order to test
+    it.
+    """
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = "script test cmd superclass"
+
+    def _exec(self, tests):
+        start_time = time.time()
+        tests(self.settings)
+        return {'elapsed_time': time.time() - start_time}
+
+    def _output(self, results):
+        b = PrintBuffer()
+        b.separator()
+        b.add_green("%s passed!\n" % self.title)
+        b.add("Elapsed time: %.2fs\n" % results['elapsed_time'])
+        b.separator()
+        return str(b)

--- a/framework/test/exec.py
+++ b/framework/test/exec.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sys
+import json
+import subprocess
+
+from framework.git.path import GitPath
+
+
+###############################################################################
+# helpers
+###############################################################################
+
+def prep(cmd):
+    """
+    Splits the command string into the list and finds the absolute path of
+    the script being invoked.
+    """
+    l = cmd.split(" ")
+    gp = GitPath(os.path.abspath(os.path.realpath(__file__)))
+    l[0] = os.path.join(str(gp.repository_base()), l[0])
+    return l
+
+
+###############################################################################
+# test actions that run a command
+###############################################################################
+
+
+def exec_cmd_no_error(cmd):
+    return subprocess.check_output(prep(cmd)).decode('utf-8')
+
+
+def exec_cmd_error(cmd):
+    try:
+        subprocess.check_output(prep(cmd))
+    except subprocess.CalledProcessError as e:
+        assert e.returncode == 1
+        output = e.output.decode('utf-8')
+        assert "Traceback" not in output
+        return e.returncode, output
+    sys.exit("*** command unexpectedly succeeded")
+
+
+def exec_cmd_json_no_error(cmd):
+    out = subprocess.check_output(prep(cmd)).decode('utf-8')
+    return json.dumps(json.loads(out))
+
+
+def exec_cmd_json_error(cmd):
+    try:
+        subprocess.check_output(prep(cmd))
+    except subprocess.CalledProcessError as e:
+        assert e.returncode == 1
+        output = e.output.decode('utf-8')
+        assert "Traceback" not in output
+        return e.returncode, json.dumps(json.loads(output))
+    sys.exit("*** command unexpectedly succeeded")
+
+
+###############################################################################
+# test actions that that modify a repo
+###############################################################################
+
+
+def exec_modify_fixes_check(repo, check_cmd, modify_cmd):
+    _ = exec_cmd_error(check_cmd)
+    _ = subprocess.check_output(prep(modify_cmd)).decode('utf-8')
+    repo.assert_dirty()
+    _ = exec_cmd_no_error(check_cmd)
+
+
+def exec_modify_doesnt_fix_check(repo, check_cmd, modify_cmd):
+    _ = exec_cmd_error(check_cmd)
+    _ = subprocess.check_output(prep(modify_cmd)).decode('utf-8')
+    repo.assert_dirty()
+    _ = exec_cmd_error(check_cmd)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,12 @@
+Contents
+========
+This directory contains regression tests for the scripts under `bin/`.
+
+Tests
+=====
+There should be a `test_<script>.py` file corresponding for every script in the `bin` directory. Each should cover the basic invocation options of the script to protect against breakage. They should also all be called from TravisCI.
+
+test\_all.py
+============
+
+This script is the exception, since it invokes every other test script. It runs in serial, so it takes a long time.

--- a/test/framework
+++ b/test/framework
@@ -1,0 +1,1 @@
+../framework/

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.cmd.repository import RepositoryCmds
+from test_basic_style import TestBasicStyleCmd
+from test_copyright_header import TestCopyrightHeaderCmd
+from test_clang_format import TestClangFormatCmd
+from test_clang_static_analysis import TestClangStaticAnalysisCmd
+from test_reports import TestReportsCmd
+from test_checks import TestChecksCmd
+from test_clone_configure_build import TestCloneConfigureBuildCmd
+from framework.bitcoin.setup import bitcoin_setup_build_ready_repo
+from framework.clang.setup import clang_setup_bin_dir
+from framework.clang.setup import clang_setup_test_style_file
+
+
+class TestAll(RepositoryCmds):
+    """
+    Invokes several underlying RepositoryCmd check command instances and
+    aggregates the results.
+    """
+    def __init__(self, settings):
+        repository_cmds = {
+            'basic_style':           TestBasicStyleCmd(settings),
+            'copyright_header':      TestCopyrightHeaderCmd(settings),
+            'clang_format':          TestClangFormatCmd(settings),
+            'clang_static_analysis': TestClangStaticAnalysisCmd(settings),
+            'reports':               TestReportsCmd(settings),
+            'checks':                TestChecksCmd(settings),
+            'clone_configure_build': TestCloneConfigureBuildCmd(settings),
+        }
+        super().__init__(settings, repository_cmds)
+
+    def _output(self, results):
+        reports = [(self.repository_cmds[l].title + ":\n" +
+                    self.repository_cmds[l]._output(r)) for l, r in
+                   sorted(results.items())]
+        return '\n'.join(reports)
+
+
+if __name__ == "__main__":
+    description = ("Runs all test scripts in serial to make sure they all "
+                   "pass.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    settings.repository = (
+        bitcoin_setup_build_ready_repo(settings.tmp_directory,
+                                       branch="v0.14.0"))
+    settings.test_bin_dir = clang_setup_bin_dir(settings.tmp_directory)
+    settings.test_style_file = (
+        clang_setup_test_style_file(settings.tmp_directory))
+    TestAll(settings).run()

--- a/test/test_basic_style.py
+++ b/test/test_basic_style.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.bitcoin.setup import bitcoin_setup_repo
+from framework.test.exec import exec_cmd_no_error
+from framework.test.exec import exec_cmd_error
+from framework.test.exec import exec_cmd_json_no_error
+from framework.test.exec import exec_cmd_json_error
+from framework.test.exec import exec_modify_fixes_check
+from framework.test.exec import exec_modify_doesnt_fix_check
+from framework.test.cmd import ScriptTestCmd
+
+###############################################################################
+# test
+###############################################################################
+
+
+def test_help(repository):
+    cmd = 'bin/basic_style.py -h'
+    print(exec_cmd_no_error(cmd))
+
+
+def test_report(repository):
+    cmd = 'bin/basic_style.py report -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/basic_style.py report %s' % repository
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/basic_style.py report -j3 %s' % repository
+    print(exec_cmd_no_error(cmd))
+    cmd = ('bin/basic_style.py report -j3 %s/src/init.cpp %s/src/qt/' %
+           (repository, repository))
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/basic_style.py report --json %s' % repository
+    print(exec_cmd_json_no_error(cmd))
+    cmd = ('bin/basic_style.py report --json %s/src/init.cpp %s/src/qt/' %
+           (repository, repository))
+    print(exec_cmd_json_no_error(cmd))
+    # no specified targets runs it on the path/repository it is invoked from:
+    cmd = 'bin/basic_style.py report'
+    original = os.getcwd()
+    os.chdir(str(repository))
+    print(exec_cmd_no_error(cmd))
+    os.chdir(original)
+
+
+def test_check(repository):
+    cmd = 'bin/basic_style.py check -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/basic_style.py check -j3 %s' % repository
+    e, out = exec_cmd_error(cmd)
+    print("%d\n%s" % (e, out))
+    cmd = 'bin/basic_style.py check --json %s' % repository
+    e, out = exec_cmd_json_error(cmd)
+    print("%d\n%s" % (e, out))
+    cmd = 'bin/basic_style.py check %s/src/init.cpp' % repository
+    print(exec_cmd_no_error(cmd))
+
+
+def test_fix(repository):
+    cmd = 'bin/basic_style.py fix -h'
+    print(exec_cmd_no_error(cmd))
+    check_cmd = "bin/basic_style.py check %s" % repository
+    modify_cmd = "bin/basic_style.py fix %s" % repository
+    exec_modify_fixes_check(repository, check_cmd, modify_cmd)
+    repository.reset_hard_head()
+
+
+def tests(settings):
+    test_help(settings.repository)
+    test_report(settings.repository)
+    test_check(settings.repository)
+    test_fix(settings.repository)
+
+
+class TestBasicStyleCmd(ScriptTestCmd):
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = __file__
+
+    def _exec(self):
+        return super()._exec(tests)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("Tests basic_style.py through its range of subcommands and "
+                   "options.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    settings.repository = bitcoin_setup_repo(settings.tmp_directory,
+                                             branch="v0.14.0")
+    TestBasicStyleCmd(settings).run()

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.test.exec import exec_cmd_no_error
+from framework.test.exec import exec_cmd_error
+from framework.test.exec import exec_cmd_json_no_error
+from framework.test.exec import exec_cmd_json_error
+from framework.test.exec import exec_modify_fixes_check
+from framework.test.exec import exec_modify_doesnt_fix_check
+from framework.bitcoin.setup import bitcoin_setup_build_ready_repo
+from framework.clang.setup import clang_setup_bin_dir
+from framework.clang.setup import clang_setup_test_style_file
+from framework.test.cmd import ScriptTestCmd
+
+###############################################################################
+# test
+###############################################################################
+
+
+def tests(settings):
+    cmd = 'bin/checks.py -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/checks.py --force --json -j3 %s' % settings.repository
+    print(exec_cmd_json_error(cmd))
+    cmd = ('bin/checks.py --force -b %s -s %s -j3 %s' %
+           (settings.test_bin_dir, settings.test_style_file,
+            settings.repository))
+    print("%d\n%s" % exec_cmd_error(cmd))
+    # put the results in a different directory:
+    test_tmp_dir = os.path.join(settings.tmp_directory,
+                                "another-tmp-directory")
+    # no specified targets runs it on the path/repository it is invoked from:
+    cmd = 'bin/checks.py --force -j3 -t %s' % test_tmp_dir
+    original = os.getcwd()
+    os.chdir(str(settings.repository))
+    print("%d\n%s" % exec_cmd_error(cmd))
+    os.chdir(original)
+
+
+class TestChecksCmd(ScriptTestCmd):
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = __file__
+
+    def _exec(self):
+        return super()._exec(tests)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("Tests checks.py through its range of options.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    settings.repository = (
+        bitcoin_setup_build_ready_repo(settings.tmp_directory,
+                                       branch="v0.14.0"))
+    settings.test_bin_dir = clang_setup_bin_dir(settings.tmp_directory)
+    settings.test_style_file = (
+        clang_setup_test_style_file(settings.tmp_directory))
+    TestChecksCmd(settings).run()

--- a/test/test_clang_format.py
+++ b/test/test_clang_format.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.test.exec import exec_cmd_no_error
+from framework.test.exec import exec_cmd_error
+from framework.test.exec import exec_cmd_json_no_error
+from framework.test.exec import exec_cmd_json_error
+from framework.test.exec import exec_modify_fixes_check
+from framework.test.exec import exec_modify_doesnt_fix_check
+from framework.bitcoin.setup import bitcoin_setup_repo
+from framework.clang.setup import clang_setup_bin_dir
+from framework.clang.setup import clang_setup_test_style_file
+from framework.test.cmd import ScriptTestCmd
+
+
+###############################################################################
+# test
+###############################################################################
+
+
+def test_help(repository):
+    cmd = 'bin/clang_format.py -h'
+    print(exec_cmd_no_error(cmd))
+
+
+def test_report(repository, test_bin_dir, test_style_file):
+    cmd = 'bin/clang_format.py report -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/clang_format.py report %s' % repository
+    print(exec_cmd_no_error(cmd))
+    cmd = ('bin/clang_format.py report -j3 %s/src/init.cpp %s/src/qt/' %
+           (repository, repository))
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/clang_format.py report --json %s' % repository
+    print(exec_cmd_json_no_error(cmd))
+    cmd = 'bin/clang_format.py report -b %s %s' % (test_bin_dir, repository)
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/clang_format.py report -s %s %s' % (test_style_file, repository)
+    print(exec_cmd_no_error(cmd))
+    # no specified targets runs it on the path/repository it is invoked from:
+    cmd = 'bin/clang_format.py report'
+    original = os.getcwd()
+    os.chdir(str(repository))
+    print(exec_cmd_no_error(cmd))
+    os.chdir(original)
+
+
+def test_check(repository, test_bin_dir, test_style_file):
+    cmd = 'bin/clang_format.py check -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/clang_format.py check -j3 --force %s' % repository
+    print("%d\n%s" % exec_cmd_error(cmd))
+    cmd = 'bin/clang_format.py check --json --force %s' % repository
+    e, out = exec_cmd_json_error(cmd)
+    print("%d\n%s" % (e, out))
+    cmd = ('bin/clang_format.py check --force %s/src/bench/bench_bitcoin.cpp' %
+           repository)
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/clang_format.py check --force -b %s %s' % (test_bin_dir,
+                                                          repository)
+    print("%d\n%s" % exec_cmd_error(cmd))
+    cmd = 'bin/clang_format.py check -s %s %s' % (test_style_file, repository)
+    print("%d\n%s" % exec_cmd_error(cmd))
+
+
+def test_format(repository):
+    cmd = 'bin/clang_format.py format -h'
+    print(exec_cmd_no_error(cmd))
+    check_cmd = "bin/clang_format.py check --force %s" % repository
+    modify_cmd = "bin/clang_format.py format --force %s" % repository
+    # Two rounds of 'format' are needed to adjust the style of
+    # src/validation.cpp to match, so this fails.
+    exec_modify_doesnt_fix_check(repository, check_cmd, modify_cmd)
+    repository.reset_hard_head()
+    check_cmd = ("bin/clang_format.py check --force %s/src/init.cpp" %
+                 repository)
+    modify_cmd = ("bin/clang_format.py format --force %s/src/init.cpp" %
+                  repository)
+    exec_modify_fixes_check(repository, check_cmd, modify_cmd)
+    repository.reset_hard_head()
+
+
+def tests(settings):
+    test_help(settings.repository)
+    test_report(settings.repository, settings.test_bin_dir,
+                settings.test_style_file)
+    test_check(settings.repository, settings.test_bin_dir,
+               settings.test_style_file)
+    test_format(settings.repository)
+
+
+class TestClangFormatCmd(ScriptTestCmd):
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = __file__
+
+    def _exec(self):
+        return super()._exec(tests)
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("Tests clang_format.py through its range of "
+                   "subcommands and options.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    settings.repository = bitcoin_setup_repo(settings.tmp_directory,
+                                             branch="v0.14.0")
+    settings.test_bin_dir = clang_setup_bin_dir(settings.tmp_directory)
+    settings.test_style_file = (
+        clang_setup_test_style_file(settings.tmp_directory))
+    TestClangFormatCmd(settings).run()

--- a/test/test_clang_static_analysis.py
+++ b/test/test_clang_static_analysis.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.test.exec import exec_cmd_no_error
+from framework.test.exec import exec_cmd_error
+from framework.test.exec import exec_cmd_json_no_error
+from framework.test.exec import exec_cmd_json_error
+from framework.test.exec import exec_modify_fixes_check
+from framework.test.exec import exec_modify_doesnt_fix_check
+from framework.bitcoin.setup import bitcoin_setup_build_ready_repo
+from framework.clang.setup import clang_setup_bin_dir
+from framework.test.cmd import ScriptTestCmd
+
+###############################################################################
+# test
+###############################################################################
+
+
+def test_help(repository):
+    cmd = 'bin/clang_static_analysis.py -h'
+    print(exec_cmd_no_error(cmd))
+
+
+def test_report(repository, tmp_directory, test_bin_dir):
+    cmd = 'bin/clang_static_analysis.py report -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = ("bin/clang_static_analysis.py report -j3 %s/src/init.cpp "
+           "%s/src/qt/" % (repository, repository))
+    print(exec_cmd_error(cmd))
+    # put the results in a different directory:
+    test_tmp_dir = os.path.join(tmp_directory, "another-tmp-directory")
+    cmd = ('bin/clang_static_analysis.py report --json -j3 -t %s %s' %
+           (test_tmp_dir, repository))
+    print(exec_cmd_json_no_error(cmd))
+    # no specified targets runs it on the path/repository it is invoked from:
+    cmd = 'bin/clang_static_analysis.py report -b %s' % test_bin_dir
+    original = os.getcwd()
+    os.chdir(str(repository))
+    print(exec_cmd_no_error(cmd))
+    os.chdir(original)
+
+
+def test_check(repository, test_bin_dir):
+    cmd = 'bin/clang_static_analysis.py check -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/clang_static_analysis.py check --json -j3 %s' % repository
+    e, out = exec_cmd_json_error(cmd)
+    print("%d\n%s" % (e, out))
+    cmd = 'bin/clang_static_analysis.py check -j3 -b %s %s' % (test_bin_dir,
+                                                               repository)
+    e, out = exec_cmd_error(cmd)
+    print("%d\n%s" % (e, out))
+
+
+def tests(settings):
+    test_help(settings.repository)
+    test_report(settings.repository, settings.tmp_directory,
+                settings.test_bin_dir)
+    test_check(settings.repository, settings.test_bin_dir)
+
+
+class TestClangStaticAnalysisCmd(ScriptTestCmd):
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = __file__
+
+    def _exec(self):
+        return super()._exec(tests)
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("Tests clang_static_analysis.py through its range of "
+                   "subcommands and options.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    settings.repository = (
+        bitcoin_setup_build_ready_repo(settings.tmp_directory,
+                                       branch="v0.14.0"))
+    settings.test_bin_dir = clang_setup_bin_dir(settings.tmp_directory)
+    TestClangStaticAnalysisCmd(settings).run()

--- a/test/test_clone_configure_build.py
+++ b/test/test_clone_configure_build.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+import shutil
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.test.exec import exec_cmd_no_error
+from framework.test.exec import exec_cmd_error
+from framework.test.exec import exec_cmd_json_no_error
+from framework.test.exec import exec_cmd_json_error
+from framework.test.exec import exec_modify_fixes_check
+from framework.test.exec import exec_modify_doesnt_fix_check
+from framework.bitcoin.setup import bitcoin_setup_build_ready_repo
+from framework.clang.setup import clang_setup_bin_dir
+from framework.clang.setup import clang_setup_test_style_file
+from framework.test.cmd import ScriptTestCmd
+
+###############################################################################
+# test
+###############################################################################
+
+
+def tests(settings):
+    bitcoin_clone_dir = os.path.join(settings.tmp_directory, "bitcoin-clone")
+    elements_clone_dir = os.path.join(settings.tmp_directory, "elements-clone")
+    cmd = 'bin/clone_configure_build.py -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/clone_configure_build.py -j3 -b v0.14.0 %s' % bitcoin_clone_dir
+    print(exec_cmd_no_error(cmd))
+    shutil.rmtree(bitcoin_clone_dir)
+    cmd = ("bin/clone_configure_build.py -u "
+           "https://github.com/ElementsProject/elements -b elements-0.13.1 %s"
+           % elements_clone_dir)
+    print(exec_cmd_no_error(cmd))
+    shutil.rmtree(elements_clone_dir)
+
+
+class TestCloneConfigureBuildCmd(ScriptTestCmd):
+    def __init__(self, settings):
+        settings.repository = "No repository for this test"
+        super().__init__(settings)
+        self.title = __file__
+
+    def _exec(self):
+        return super()._exec(tests)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("Tests clone_configure_build.py through its range of "
+                   "options.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    TestCloneConfigureBuildCmd(settings).run()

--- a/test/test_copyright_header.py
+++ b/test/test_copyright_header.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.bitcoin.setup import bitcoin_setup_repo
+from framework.test.exec import exec_cmd_no_error
+from framework.test.exec import exec_cmd_error
+from framework.test.exec import exec_cmd_json_no_error
+from framework.test.exec import exec_cmd_json_error
+from framework.test.exec import exec_modify_fixes_check
+from framework.test.exec import exec_modify_doesnt_fix_check
+from framework.test.cmd import ScriptTestCmd
+
+###############################################################################
+# test
+###############################################################################
+
+
+def test_help(repository):
+    cmd = 'bin/copyright_header.py -h'
+    print(exec_cmd_no_error(cmd))
+
+
+def test_report(repository):
+    cmd = 'bin/copyright_header.py report -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/copyright_header.py report %s' % repository
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/copyright_header.py report -j3 %s' % repository
+    print(exec_cmd_no_error(cmd))
+    cmd = ('bin/copyright_header.py report -j3 %s/src/init.cpp %s/src/qt/' %
+           (repository, repository))
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/copyright_header.py report --json %s' % repository
+    print(exec_cmd_json_no_error(cmd))
+    cmd = ('bin/copyright_header.py report --json %s/src/init.cpp %s/src/qt/' %
+           (repository, repository))
+    print(exec_cmd_json_no_error(cmd))
+    # no specified targets runs it on the path/repository it is invoked from:
+    cmd = 'bin/copyright_header.py report'
+    original = os.getcwd()
+    os.chdir(str(repository))
+    print(exec_cmd_no_error(cmd))
+    os.chdir(original)
+
+
+def test_check(repository):
+    cmd = 'bin/copyright_header.py check -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/copyright_header.py check -j3 %s' % repository
+    e, out = exec_cmd_error(cmd)
+    print("%d\n%s" % (e, out))
+    cmd = 'bin/copyright_header.py check --json %s' % repository
+    e, out = exec_cmd_json_error(cmd)
+    print("%d\n%s" % (e, out))
+    cmd = 'bin/copyright_header.py check %s/src/init.cpp' % repository
+    print(exec_cmd_no_error(cmd))
+
+
+def test_update(repository):
+    cmd = 'bin/copyright_header.py update -h'
+    print(exec_cmd_no_error(cmd))
+    check_cmd = "bin/copyright_header.py check %s" % repository
+    modify_cmd = "bin/copyright_header.py update %s" % repository
+    exec_modify_doesnt_fix_check(repository, check_cmd, modify_cmd)
+    repository.reset_hard_head()
+
+
+def test_insert(repository):
+    cmd = 'bin/copyright_header.py insert -h'
+    print(exec_cmd_no_error(cmd))
+    check_cmd = "bin/copyright_header.py check %s" % repository
+    modify_cmd = "bin/copyright_header.py insert %s/src/" % repository
+    exec_modify_doesnt_fix_check(repository, check_cmd, modify_cmd)
+    repository.reset_hard_head()
+    # results in no-op if already has a valid header
+    cmd = "bin/copyright_header.py insert %s/src/init.cpp" % repository
+    print(exec_cmd_no_error(cmd))
+    repository.assert_not_dirty()
+
+
+def tests(settings):
+    test_help(settings.repository)
+    test_report(settings.repository)
+    test_check(settings.repository)
+    test_update(settings.repository)
+    test_insert(settings.repository)
+
+
+class TestCopyrightHeaderCmd(ScriptTestCmd):
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = __file__
+
+    def _exec(self):
+        return super()._exec(tests)
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("Tests copyright_header.py through its range of "
+                   "subcommands and options.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    settings.repository = bitcoin_setup_repo(settings.tmp_directory,
+                                             branch="v0.14.0")
+    TestCopyrightHeaderCmd(settings).run()

--- a/test/test_reports.py
+++ b/test/test_reports.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import argparse
+
+from framework.argparse.option import add_tmp_directory_option
+from framework.test.exec import exec_cmd_no_error
+from framework.test.exec import exec_cmd_error
+from framework.test.exec import exec_cmd_json_no_error
+from framework.test.exec import exec_cmd_json_error
+from framework.test.exec import exec_modify_fixes_check
+from framework.test.exec import exec_modify_doesnt_fix_check
+from framework.bitcoin.setup import bitcoin_setup_build_ready_repo
+from framework.clang.setup import clang_setup_bin_dir
+from framework.clang.setup import clang_setup_test_style_file
+from framework.test.cmd import ScriptTestCmd
+
+###############################################################################
+# test
+###############################################################################
+
+
+def tests(settings):
+    cmd = 'bin/reports.py -h'
+    print(exec_cmd_no_error(cmd))
+    cmd = 'bin/reports.py --json -j3 %s' % settings.repository
+    print(exec_cmd_json_no_error(cmd))
+    cmd = 'bin/reports.py -b %s -s %s -j3 %s' % (settings.test_bin_dir,
+                                                 settings.test_style_file,
+                                                 settings.repository)
+    print(exec_cmd_no_error(cmd))
+    # put the results in a different directory:
+    test_tmp_dir = os.path.join(settings.tmp_directory,
+                                "another-tmp-directory")
+    # no specified targets runs it on the path/repository it is invoked from:
+    cmd = 'bin/reports.py -t %s' % test_tmp_dir
+    original = os.getcwd()
+    os.chdir(str(settings.repository))
+    print(exec_cmd_no_error(cmd))
+    os.chdir(original)
+
+
+class TestReportsCmd(ScriptTestCmd):
+    def __init__(self, settings):
+        super().__init__(settings)
+        self.title = __file__
+
+    def _exec(self):
+        return super()._exec(tests)
+
+
+###############################################################################
+# UI
+###############################################################################
+
+if __name__ == "__main__":
+    description = ("Tests reports.py through its range of options.")
+    parser = argparse.ArgumentParser(description=description)
+    add_tmp_directory_option(parser)
+    settings = parser.parse_args()
+    settings.repository = (
+        bitcoin_setup_build_ready_repo(settings.tmp_directory,
+                                       branch="v0.14.0"))
+    settings.test_bin_dir = clang_setup_bin_dir(settings.tmp_directory)
+    settings.test_style_file = (
+        clang_setup_test_style_file(settings.tmp_directory))
+    TestReportsCmd(settings).run()


### PR DESCRIPTION
The `bin/` directory holds scripts meant to be user-executable and helpful. It contains a collection of functionality that was previously submitted to `contrib/devtools/`, but as discussed, this repo is now considered the best place. These differ from the earlier submission in that they are now built off of the framework and have a bunch of extra amenities provided by the shared code.

The `framework/` directory holds common infrastructure that can help accelerate future scripts and automation.

The `test/` directory is a set of scripts that test the scripts in the `bin/` directory and are invoked by `.travis.yml` to prevent breakage upon future refactoring and enhancement.

The scripts all have `-h` output courtesy of `argparse` that describe functionality and options. The `bin/README.md` file also gives a quick overview.

Out of the box, this can build from scratch and compute the full set of reports for the `master` branch of `bitcoin/bitcoin` like so:

```
$ bin/clone_configure_build.py ~/bitcoin-build
(output snipped)
$ bin/reports.py ~/bitcoin-build
(output snipped)
```


The BerkeleyDb 4.8 workspace and other miscellaneous file are written to `/tmp/bitcoin-maintainer-tools/` (by default). For the clang toolchain binaries, it defaults to using the highest installed version in PATH, but it can also be pointed to a different toolchain directory (e.g. `-b ~/clang+llvm-3.9.1-x86_64-linux-gnu-debian8/`).

Where it makes sense, the scripts allow limiting the scope to individual files and/or subdirectories. Illustrated by example:

```
$ bin/clang_format.py check ~/bitcoin-build/src/init.cpp
--------------------------------------------------------------------------------
1472 files tracked in repo
 407 files in scope according to .bitcoin_maintainer_tools.json settings
   1 files examined according to listed targets
   4 parallel jobs for computing analysis
--------------------------------------------------------------------------------
A code format issue was detected in /home/isle/bitcoin-build/src/init.cpp

 +--------+         +------------+--------+---------+-----------+------------+
 | score  |         |     before |  added | removed | unchanged |      after |
 +--------+ +-------+------------+--------+---------+-----------+------------+
 | 90.39% | | lines |       1644 |    148 |     158 |      1486 |       1634 |
 +--------+ +-------+------------+--------+---------+-----------+------------+
--------------------------------------------------------------------------------
These files can be formatted by running:
$ clang_format.py format [option [option ...]] [target [target ...]]
--------------------------------------------------------------------------------

*** code format issue found

```

The repository is and .clang_format file is inferred from the targets. They can be formatted and re-checked like so:

```
$ bin/clang_format.py format ~/bitcoin-build/src/init.cpp
$ bin/clang_format.py check ~/bitcoin-build/src/init.cpp
--------------------------------------------------------------------------------
1472 files tracked in repo
 407 files in scope according to .bitcoin_maintainer_tools.json settings
   1 files examined according to listed targets
   4 parallel jobs for computing analysis
--------------------------------------------------------------------------------
No format issues found!
--------------------------------------------------------------------------------
```


Also, the `report`  and `check` subcommands of the scripts all have a `--json` mode that provides the full information to assist with programmatic uses (bisecting, charting, etc.).

The intention is to provide utility for the main `bitcoin/bitcoin` project, but the scripts appear to work well for forks too. For example, you can point to Elements, build, and compute the analysis and reports:
```
$ bin/clone_configure_build.py -u https://github.com/ElementsProject/elements -b elements-0.13.1 ~/elements-build
$ bin/reports.py ~/elements-build
```

If the target repo provides a `.bitcoin-maintainer-tools.json` file, it helps the tools to know which subtrees to ignore, etc. If the repo doesn't have one, it uses `.fallback-bitcoin-maintainer-tools.json` which holds the appropriate settings for `v0.14.0`.