### PR TITLE
Set QT_RCC_SOURCE_DATE_OVERRIDE so that bitcoin-qt is deterministic

### DIFF
--- a/build-for-compare.py
+++ b/build-for-compare.py
@@ -63,6 +63,9 @@ CPPFLAGS=[]
 OBJCOPY_ARGS=['-R.note.gnu.build-id','-g','-S']
 OBJDUMP_ARGS=['-C','--no-show-raw-insn','-d','-r']
 
+# Set QT_RCC_SOURCE_DATE_OVERRIDE so that bitcoin-qt is deterministic
+os.environ['QT_RCC_SOURCE_DATE_OVERRIDE'] = '1'
+
 # These can be overridden from the environment
 GIT=os.getenv('GIT', 'git')
 MAKE=os.getenv('MAKE', 'make')


### PR DESCRIPTION
Set `QT_RCC_SOURCE_DATE_OVERRIDE` to 1 in `build-for-compare.py`, so that `bitcoin-qt` builds are deterministic.

Related IRC discussion [here (line 114)](http://www.erisian.com.au/bitcoin-core-dev/log-2019-08-01.html).