### PR TITLE
github-merge: warn if merge message contains an @

### DIFF
--- a/github-merge.py
+++ b/github-merge.py
@@ -188,7 +188,7 @@ def make_acks_message(head_commit, acks):
         ack_str ='\n\nTop commit has no ACKs.\n'
     return ack_str
 
-def print_merge_details(pull, title, branch, base_branch, head_branch, acks):
+def print_merge_details(pull, title, branch, base_branch, head_branch, acks, message):
     print('%s#%s%s %s %sinto %s%s' % (ATTR_RESET+ATTR_PR,pull,ATTR_RESET,title,ATTR_RESET+ATTR_PR,branch,ATTR_RESET))
     subprocess.check_call([GIT,'log','--graph','--topo-order','--pretty=format:'+COMMIT_FORMAT,base_branch+'..'+head_branch])
     if acks is not None:
@@ -198,6 +198,8 @@ def print_merge_details(pull, title, branch, base_branch, head_branch, acks):
                 print('* {} {}({}){}'.format(message, ATTR_NAME, name, ATTR_RESET))
         else:
             print('{}Top commit has no ACKs!{}'.format(ATTR_WARN, ATTR_RESET))
+    if message is not None and '@' in message:
+        print('{}Merge message contains an @!{}'.format(ATTR_WARN, ATTR_RESET))
 
 def parse_arguments():
     epilog = '''
@@ -326,7 +328,7 @@ def main():
             print("ERROR: Unable to compute tree hash")
             sys.exit(4)
 
-        print_merge_details(pull, title, branch, base_branch, head_branch, None)
+        print_merge_details(pull, title, branch, base_branch, head_branch, acks=None, message=None)
         print()
 
         # Run test command if configured.
@@ -376,7 +378,7 @@ def main():
             sys.exit(4)
 
         # Sign the merge commit.
-        print_merge_details(pull, title, branch, base_branch, head_branch, acks)
+        print_merge_details(pull, title, branch, base_branch, head_branch, acks, message)
         while True:
             reply = ask_prompt("Type 's' to sign off on the above merge, or 'x' to reject and exit.").lower()
             if reply == 's':


### PR DESCRIPTION
Fixes #30. Warn if the merge message contains an "@".

Can be tested with https://github.com/bitcoin/bitcoin/pull/16439.

```bash
merge 16439
Auto-merging test/functional/rpc_blockchain.py
Auto-merging src/rpc/util.cpp
Auto-merging src/rpc/rawtransaction.cpp
Auto-merging src/rpc/blockchain.cpp
Auto-merging src/qt/rpcconsole.cpp
Auto-merging src/bitcoin-cli.cpp
#16439 RPC: support "@height" in place of blockhash for getblock etc into master
* f4bcae95ae89cbd6512b4347bb0ba68ac8fe4d35 qt getblock %123 (Anthony Towns) (pull/16439/head)
* 817a8d2e42b521cd2910a1b0a2ab3f6e4219b831 bitcoin-cli: support "getblock %height" by doing "getblockhash height" on client side (Anthony Towns)
* c27f59ff71e2d67231631469ac88609a39d18f35 Add Type::BLOCK_REF for hash/@height (Anthony Towns)
* 792c2a5dbca346e1b693446accd68b6a5448292f rpc: getblockstats deprecate hash_or_height (Anthony Towns)
* e0ef6430628ecd1651a28bbeb65c9c5651414fc4 rpc: @height for other rpc commands accepting a blockhash (Anthony Towns)
* a1118b68ad1eb14501600e1badc3dcbd4e2b2365 rpc: Add test for getblockbyheight (Emil Engler)
* f48dac4d1ca1fe753b2ff3928ae80ccb12abff34 rpc: getblock @height (Anthony Towns)

Dropping you on a shell so you can try building/testing the merged source.
Run 'git diff HEAD~' to show the changes being merged.
Type 'exit' when done.
bash-3.2$ exit
exit
[pull/16439/local-merge f10d37f36] Merge #16439: RPC: support "@height" in place of blockhash for getblock etc
 Date: Sun Aug 25 19:10:56 2019 +0800
#16439 RPC: support "@height" in place of blockhash for getblock etc into master
* f4bcae95ae89cbd6512b4347bb0ba68ac8fe4d35 qt getblock %123 (Anthony Towns) (pull/16439/head)
* 817a8d2e42b521cd2910a1b0a2ab3f6e4219b831 bitcoin-cli: support "getblock %height" by doing "getblockhash height" on client side (Anthony Towns)
* c27f59ff71e2d67231631469ac88609a39d18f35 Add Type::BLOCK_REF for hash/@height (Anthony Towns)
* 792c2a5dbca346e1b693446accd68b6a5448292f rpc: getblockstats deprecate hash_or_height (Anthony Towns)
* e0ef6430628ecd1651a28bbeb65c9c5651414fc4 rpc: @height for other rpc commands accepting a blockhash (Anthony Towns)
* a1118b68ad1eb14501600e1badc3dcbd4e2b2365 rpc: Add test for getblockbyheight (Emil Engler)
* f48dac4d1ca1fe753b2ff3928ae80ccb12abff34 rpc: getblock @height (Anthony Towns)
Top commit has no ACKs!
Merge message contains an @!
Type 's' to sign off on the above merge, or 'x' to reject and exit. x

Not signing off on merge, exiting.
```