### PR TITLE
github-merge: support submodules

### DIFF
--- a/github-merge.py
+++ b/github-merge.py
@@ -125,6 +125,8 @@ def tree_sha512sum(commit='HEAD'):
     for line in subprocess.check_output([GIT, 'ls-tree', '--full-tree', '-r', commit]).splitlines():
         name_sep = line.index(b'\t')
         metadata = line[:name_sep].split() # perms, 'blob', blobid
+        if metadata[1] == b'commit':
+            continue # Ignore submodule
         assert(metadata[1] == b'blob')
         name = line[name_sep+1:]
         files.append(name)


### PR DESCRIPTION
I tried merging a simple [pull request in another project](https://github.com/blockchain/libwally-swift/pull/11#issuecomment-526672191) as follows:

```sh
../bitcoin-maintainer-tools/github-merge.py 11
```

This failed with:

```
  File "../bitcoin-maintainer-tools/github-merge.py", line 129, in tree_sha512sum
    assert(metadata[1] == b'blob')
```

That's because `git ls-tree --full-tree -r HEAD` shows a git submodule as `b'commit'`. Notice that the pull request didn't involve the git submodule.

I don't know if this is the correct solution, just that it makes the error go away.