### PR TITLE
update-translations: Speed up transifex download process

### DIFF
--- a/update-translations.py
+++ b/update-translations.py
@@ -53,7 +53,7 @@ def remove_current_translations():
         os.remove(name + '.orig')
 
 def fetch_all_translations():
-    if subprocess.call([TX, 'pull', '-f', '-a']):
+    if subprocess.call([TX, 'pull', '-f', '-a', '--parallel', '--minimum-perc=1']):
         print('Error while fetching translations', file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
--parallel flag downloads all translation files at once instead of one by one, making the process much faster.
--minimum-perc flag allows to specify minimum completion percentage. Setting this to 1% makes sure that empty translation files never get downloaded, speeding up the process even further.