### PR TITLE
Use str.splitlines where appropriate

### DIFF
--- a/backport.py
+++ b/backport.py
@@ -72,7 +72,7 @@ else: # no colors if we're printing a bash script
 if not execute:
     print('set -e')
 for t in to_backport:
-    msg = t[1].message.rstrip().split('\n')
+    msg = t[1].message.rstrip().splitlines()
     assert(msg[1] == '')
     print('{a.hsh}# {a.head}{}{a.reset}'.format(msg[0],a=Attr))
     # XXX get the commits in the merge from the actual commit data instead of from the commit message

--- a/build-for-compare.py
+++ b/build-for-compare.py
@@ -164,7 +164,7 @@ def objdump_all(srcdir: str, tgtdir: str):
         # postprocess- break into sections separated by 'Disassembly of section...'
         sections = defaultdict(list)
         funcname = ''
-        for line in out.split('\n'):
+        for line in out.splitlines():
             match = re.match('^Disassembly of section (.*):$', line)
             if match:
                 funcname = match.group(1)

--- a/github-merge.py
+++ b/github-merge.py
@@ -173,7 +173,7 @@ def get_acks_from_comments(head_commit, comments):
     head_abbrev = head_commit[0:6]
     acks = []
     for c in comments:
-        review = [l for l in c['body'].split('\r\n') if 'ACK' in l and head_abbrev in l]
+        review = [l for l in c['body'].splitlines() if 'ACK' in l and head_abbrev in l]
         if review:
             acks.append((c['user']['login'], review[0]))
     return acks

--- a/list-pulls.py
+++ b/list-pulls.py
@@ -154,7 +154,7 @@ if len(sys.argv) >= 4:
 # set of all commits
 commits = subprocess.check_output([GIT, 'rev-list', '--reverse', '--topo-order', ref_from+'..'+ref_to])
 commits = commits.decode()
-commits = remove_last(commits.split('\n'))
+commits = remove_last(commits.splitlines())
 commits_list = commits
 commits = set(commits)
 
@@ -166,7 +166,7 @@ for commit in commits:
     info = subprocess.check_output([GIT, 'show', '-s', '--format=%B%x00%P', commit])
     info = info.decode()
     (message, parents) = info.split('\0')
-    title = message.rstrip().split('\n')[0]
+    title = message.rstrip().splitlines()[0]
     parents = parents.rstrip().split(' ')
     commit_data[commit] = CommitData(commit, message, title, parents)
 
@@ -182,7 +182,7 @@ def parse_commit_message(msg):
     Parse backport commit message.
     '''
     retval = CommitMetaData()
-    for line in msg.split('\n'):
+    for line in msg.splitlines():
         m = re.match('Github-Pull: #?(\d+)', line, re.I)
         if m:
             retval.pull = int(m.group(1))
@@ -210,7 +210,7 @@ for c in commit_data.values():
             #print('removing ', c.sha)
             sub_commits = subprocess.check_output([GIT, 'rev-list', c.parents[0]+'..'+c.parents[1]])
             sub_commits = sub_commits.decode()
-            sub_commits = set(sub_commits.rstrip().split('\n'))
+            sub_commits = set(sub_commits.rstrip().splitlines())
             pull = int(match.group(1))
 
             # remove commits that are not in the global list


### PR DESCRIPTION
Before (only tested github-merge):

```
[pull/17218/local-merge e3ecb347e4] Merge #17218: Replace the LogPrint function with a macro
 Date: Fri Nov 1 10:08:05 2019 -0400
#17218 Replace the LogPrint function with a macro into master
* 8734c856f85cb506fa97596383dd7e7b9edd7e03 Replace the LogPrint function with a macro (Jeffrey Czyz) (pull/17218/head)
ACKs:
* I've thought about it a bit and I think for the reason I gave above I'd
want to NACK this change.

If there are motivating examples for not evaluating the calls, they should
be fixed one by one.

It would also seem like perfect forwarding and inline can help with some of
these concerns too to nudge the compiler to defer constructing strings or
whatever.

On Tue, Oct 22, 2019, 1:47 PM Jeffrey Czyz <notifications@github.com> wrote:

> *@jkczyz* commented on this pull request.
> ------------------------------
>
> In src/logging.h
> <https://github.com/bitcoin/bitcoin/pull/17218#discussion_r337741803>:
>
> > @@ -155,12 +155,10 @@ static inline void LogPrintf(const char* fmt, const Args&... args)
>      }
>  }
>
> -template <typename... Args>
> -static inline void LogPrint(const BCLog::LogFlags& category, const Args&... args)
> -{
> -    if (LogAcceptCategory((category))) {
> -        LogPrintf(args...);
> -    }
> -}
> +#define LogPrint(category, ...) do { \
>
> Done in 8734c85
> <https://github.com/bitcoin/bitcoin/commit/8734c856f85cb506fa97596383dd7e7b9edd7e03>
> .
>
> —
> You are receiving this because you commented.
> Reply to this email directly, view it on GitHub
> <https://github.com/bitcoin/bitcoin/pull/17218?email_source=notifications&email_token=AAGYN6ZCEVD7RSKFT4WLQPTQP5RGBA5CNFSM4JDTSZXKYY3PNVWWK3TUL52HS4DFWFIHK3DMKJSXC5LFON2FEZLWNFSXPKTDN5WW2ZLOORPWSZGOCI2YLLA#discussion_r337741803>,
> or unsubscribe
> <https://github.com/notifications/unsubscribe-auth/AAGYN636IOUCRCYGJ2VKPFDQP5RGBANCNFSM4JDTSZXA>
> .
>
 (JeremyRubin)
* ACK 8734c856f85cb506fa97596383dd7e7b9edd7e03 (jnewbery)
Type 's' to sign off on the above merge, or 'x' to reject and exit. x
```

After:

```
[pull/17218/local-merge 74208557d0] Merge #17218: Replace the LogPrint function with a macro
 Date: Fri Nov 1 10:14:07 2019 -0400
#17218 Replace the LogPrint function with a macro into master
* 8734c856f85cb506fa97596383dd7e7b9edd7e03 Replace the LogPrint function with a macro (Jeffrey Czyz) (pull/17218/head)
ACKs:
* ACK 8734c856f85cb506fa97596383dd7e7b9edd7e03 (jnewbery)
Type 's' to sign off on the above merge, or 'x' to reject and exit. s
```