### PR TITLE
github-merge: Add missing newline

### DIFF
--- a/github-merge.py
+++ b/github-merge.py
@@ -190,7 +190,7 @@ def make_acks_message(head_commit, acks) -> str:
 
 def print_merge_details(pull_reference, title, branch, base_branch, head_branch, acks, message):
     print('{}{}{} {} {}into {}{}'.format(ATTR_RESET+ATTR_PR,pull_reference,ATTR_RESET,title,ATTR_RESET+ATTR_PR,branch,ATTR_RESET))
-    subprocess.check_call([GIT,'--no-pager','log','--graph','--topo-order','--pretty=format:'+COMMIT_FORMAT,base_branch+'..'+head_branch])
+    subprocess.check_call([GIT,'--no-pager','log','--graph','--topo-order','--pretty=tformat:'+COMMIT_FORMAT,base_branch+'..'+head_branch])
     if acks is not None:
         if acks:
             print('{}ACKs:{}'.format(ATTR_PR, ATTR_RESET))


### PR DESCRIPTION
Now that `--no-pager` is specified, no automatic newline is added by `less` anymore. Use `tformat` instead of `format` to make sure it gets added and the message about ACKs doesn't appear on the same line.

Fixes a problem in introduced in #64. I think this is the only occurrence but please check.