### PR TITLE
make-tag: Add check for MSVC PACKAGE_STRING, PACKAGE_VERSION

### DIFF
--- a/make-tag.py
+++ b/make-tag.py
@@ -97,19 +97,28 @@ def check_msvc_config_h(spec):
     filename = 'build_msvc/bitcoin_config.h'
     with open(filename) as f:
         for line in f:
-            m = re.match("#define CLIENT_VERSION_([A-Z_]+) ([0-9a-z]+)", line)
+            m = re.match("#define ([A-Z_]+) (.+)$", line)
             if m:
                 info[m.group(1)] = m.group(2)
     # check if IS_RELEASE is set
-    if info["IS_RELEASE"] != "true":
+    if info["CLIENT_VERSION_IS_RELEASE"] != "true":
         print(f'{filename}: IS_RELEASE is not set to true', file=sys.stderr)
         sys.exit(1)
 
+    package_name = info['PACKAGE_NAME'][1:-1]
+    if info['PACKAGE_STRING'] != f'"{package_name} {spec.major}.{spec.minor}.{spec.revision}"':
+        print(f'PACKAGE_STRING is not set correctly for msvc')
+        sys.exit(1)
+
+    if info['PACKAGE_VERSION'] != f'"{spec.major}.{spec.minor}.{spec.revision}"':
+        print(f'PACKAGE_VERSION is not set correctly for msvc')
+        sys.exit(1)
+
     msvc_spec = VersionSpec(
-            int(info['MAJOR']),
-            int(info['MINOR']),
-            int(info['REVISION']),
-            int(info['BUILD']),
+            int(info['CLIENT_VERSION_MAJOR']),
+            int(info['CLIENT_VERSION_MINOR']),
+            int(info['CLIENT_VERSION_REVISION']),
+            int(info['CLIENT_VERSION_BUILD']),
             None, # RC is not specified here
         )
 


### PR DESCRIPTION
Make sure that the scattered, redundant MSVC version tags are consistent too…