### PR TITLE
github-merge: Always include repo_from in the merge commit message

### DIFF
--- a/github-merge.py
+++ b/github-merge.py
@@ -290,7 +290,7 @@ def main():
         sys.exit(1)
     title = info['title'].strip()
     body = info['body'].strip()
-    pull_reference = (repo_from if is_other_fetch_repo else '') + '#' + pull
+    pull_reference = repo_from + '#' + pull
     # precedence order for destination branch argument:
     #   - command line argument
     #   - githubmerge.branch setting


### PR DESCRIPTION
This adds clarity if a repository is pushed to a new location where the numeric ids have a different meaning or are missing altogether.