### PR TITLE
github-merge: Change --repo_from to --repo-from

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For example, if the "to" repo is identical to the "from" repo:
 Otherwise, for a differing "from" repo:
 
 ```bash
-./github-merge.py --repo_from=bitcoin-core/gui 1234
+./github-merge.py --repo-from=bitcoin-core/gui 1234
 ```
 
 will fetch the pull request from another monotree repository. Be sure to also set `githubmerge.pushmirrors` (see below).

--- a/github-merge.py
+++ b/github-merge.py
@@ -246,7 +246,7 @@ def parse_arguments():
     '''
     parser = argparse.ArgumentParser(description='Utility to merge, sign and push github pull requests',
             epilog=epilog)
-    parser.add_argument('--repo_from', metavar='repo_from', type=str, nargs='?',
+    parser.add_argument('--repo-from', '-r', metavar='repo_from', type=str, nargs='?',
         help='The repo to fetch the pull request from. Useful for monotree repositories. Can only be specified when branch==master. (default: githubmerge.repository setting)')
     parser.add_argument('pull', metavar='PULL', type=int, nargs=1,
         help='Pull request ID to merge')
@@ -304,7 +304,7 @@ def main():
     else:
         push_mirrors = []
         if is_other_fetch_repo:
-            print('ERROR: repo_from is only supported for the master development branch')
+            print('ERROR: --repo-from is only supported for the master development branch')
             sys.exit(1)
 
     # Initialize source branches


### PR DESCRIPTION
Change `--repo_from` to `--repo-from`. Kebab case is almost universally used for command-line arguments. Besides that, `-` is easier to type on most keyboards than `_`.

Also add a short option alternative, `-r`.