### PR TITLE
gitian-verify: offline flag for gpgme to disable network connections

### DIFF
--- a/gitian-verify.py
+++ b/gitian-verify.py
@@ -61,7 +61,7 @@ class VerificationInterface:
     EXPIRED_KEY = 2
 
     def __init__(self) -> None:
-        self.ctx = gpg.Context()
+        self.ctx = gpg.Context(offline=True)
 
     def verify_detached(self, sig: bytes, result: bytes) -> VerificationResult:
         '''


### PR DESCRIPTION
Related to #95.

Setting the offline flag for gpgme to to disable network connections:

For the OpenPGP protocol offline mode entirely disables the use of the Dirmngr and will thus guarantee that no network connections are done as part of an operation on this context. It has only an effect with GnuPG versions 2.1.23 or later.
 [Documentation Offline Mode](https://www.gnupg.org/documentation/manuals/gpgme/Offline-Mode.html)

Tested on macOS 11.3 and gpg 2.3.1.