### PR TITLE
Do not include actually untranslated strings into the repo

### DIFF
--- a/update-translations.py
+++ b/update-translations.py
@@ -154,7 +154,6 @@ def postprocess_translations(reduce_diff_hacks=False):
     for (filename,filepath) in all_ts_files():
         os.rename(filepath, filepath+'.orig')
 
-    have_errors = False
     for (filename,filepath) in all_ts_files('.orig'):
         # pre-fixups to cope with transifex output
         parser = ET.XMLParser(encoding='utf-8') # need to override encoding because 'utf8' is not understood only 'utf-8'
@@ -189,7 +188,6 @@ def postprocess_translations(reduce_diff_hacks=False):
                     if not valid: # set type to unfinished and clear string if invalid
                         translation_node.clear()
                         translation_node.set('type', 'unfinished')
-                        have_errors = True
 
                 # Remove location tags
                 for location in message.findall('location'):
@@ -219,7 +217,6 @@ def postprocess_translations(reduce_diff_hacks=False):
                 f.write(out)
         else:
             tree.write(filepath, encoding='utf-8')
-    return have_errors
 
 def update_git():
     '''

--- a/update-translations.py
+++ b/update-translations.py
@@ -204,6 +204,9 @@ def postprocess_translations(reduce_diff_hacks=False):
                 if not postprocess_message(filename, message):
                     context.remove(message);
 
+            if not context.findall('message'):
+                root.remove(context)
+
         # check if document is (virtually) empty, and remove it if so
         num_messages = 0
         for context in root.findall('context'):

--- a/update-translations.py
+++ b/update-translations.py
@@ -154,6 +154,9 @@ def postprocess_message(filename, message):
     if numerus:
         translations = [i.text for i in translation_node.findall('numerusform')]
     else:
+        if translation_node.text is None or translation_node.text == source:
+            return False
+
         translations = [translation_node.text]
 
     for translation in translations:

--- a/update-translations.py
+++ b/update-translations.py
@@ -144,9 +144,12 @@ def contains_bitcoin_addr(text, errors):
     return False
 
 def postprocess_message(filename, message):
+    translation_node = message.find('translation')
+    if translation_node.get('type') == 'unfinished':
+        return False
+
     numerus = message.get('numerus') == 'yes'
     source = message.find('source').text
-    translation_node = message.find('translation')
     # pick all numerusforms
     if numerus:
         translations = [i.text for i in translation_node.findall('numerusform')]
@@ -162,17 +165,12 @@ def postprocess_message(filename, message):
         for error in errors:
             print('%s: %s' % (filename, error))
 
-        if not valid: # set type to unfinished and clear string if invalid
-            translation_node.clear()
-            translation_node.set('type', 'unfinished')
+        if not valid:
+            return False
 
     # Remove location tags
     for location in message.findall('location'):
         message.remove(location)
-
-    # Remove entire message if it is an unfinished translation
-    if translation_node.get('type') == 'unfinished':
-        return False
 
     return True
 

--- a/update-translations.py
+++ b/update-translations.py
@@ -28,8 +28,8 @@ TX = 'tx'
 SOURCE_LANG = 'bitcoin_en.ts'
 # Directory with locale files
 LOCALE_DIR = 'src/qt/locale'
-# Minimum number of messages for translation to be considered at all
-MIN_NUM_MESSAGES = 10
+# Minimum number of non-numerus messages for translation to be considered at all
+MIN_NUM_NONNUMERUS_MESSAGES = 10
 # Regexp to check for Bitcoin addresses
 ADDRESS_REGEXP = re.compile('([13]|bc1)[a-zA-Z0-9]{30,}')
 # Path to git
@@ -208,12 +208,14 @@ def postprocess_translations(reduce_diff_hacks=False):
                 root.remove(context)
 
         # check if document is (virtually) empty, and remove it if so
-        num_messages = 0
+        num_nonnumerus_messages = 0
         for context in root.findall('context'):
             for message in context.findall('message'):
-                num_messages += 1
-        if num_messages < MIN_NUM_MESSAGES:
-            print('Removing %s, as it contains only %i messages' % (filepath, num_messages))
+                if message.get('numerus') != 'yes':
+                    num_nonnumerus_messages += 1
+
+        if num_nonnumerus_messages < MIN_NUM_NONNUMERUS_MESSAGES:
+            print('Removing %s, as it contains only %i non-numerus messages' % (filepath, num_nonnumerus_messages))
             continue
 
         # write fixed-up tree


### PR DESCRIPTION
While working on adapting the `update-translations.py` script to imported XLIFF files, I noted that strings, that are marked "translated", are, actually, untranslated, i.e., a translation is the same as a source.

This PR solves this issue.

Translation updating numbers for the recent translation state (could differs later):
- branch 0.20:
  - master: -2021 / +30415 lines
  - this PR: -30551 / +13642 lines

- branch 0.21:
  - master: -4818 / +11815 lines
  - this PR: -47035 / +10539 lines
