### PR TITLE
Make update-translations.py work with XLIFF Transifex translations

### DIFF
--- a/update-translations.py
+++ b/update-translations.py
@@ -24,8 +24,8 @@ import xml.etree.ElementTree as ET
 
 # Name of transifex tool
 TX = 'tx'
-# Name of source language file
-SOURCE_LANG = 'bitcoin_en.ts'
+# Name of source language file without extension
+SOURCE_LANG = 'bitcoin_en'
 # Directory with locale files
 LOCALE_DIR = 'src/qt/locale'
 # Minimum number of non-numerus messages for translation to be considered at all
@@ -36,6 +36,10 @@ ADDRESS_REGEXP = re.compile('([13]|bc1)[a-zA-Z0-9]{30,}')
 GIT = os.getenv("GIT", "git")
 # Original content file suffix
 ORIGINAL_SUFFIX = '.orig'
+# Native Qt translation file (TS) format
+FORMAT_TS = '.ts'
+# XLIFF file format
+FORMAT_XLIFF = '.xlf'
 
 def check_at_repository_root():
     if not os.path.exists('.git'):
@@ -115,10 +119,10 @@ def check_format_specifiers(source, translation, errors, numerus):
             return False
     return True
 
-def all_ts_files(suffix='', include_source=False):
+def all_ts_files(file_format=FORMAT_TS, suffix='', include_source=False):
     for filename in os.listdir(LOCALE_DIR):
         # process only language files, and do not process source language
-        if not filename.endswith('.ts'+suffix) or (not include_source and filename == SOURCE_LANG+suffix):
+        if not filename.endswith(file_format + suffix) or (not include_source and filename == SOURCE_LANG + file_format + suffix):
             continue
         if suffix: # remove provided suffix
             filename = filename[0:-len(suffix)]

--- a/update-translations.py
+++ b/update-translations.py
@@ -34,6 +34,8 @@ MIN_NUM_NONNUMERUS_MESSAGES = 10
 ADDRESS_REGEXP = re.compile('([13]|bc1)[a-zA-Z0-9]{30,}')
 # Path to git
 GIT = os.getenv("GIT", "git")
+# Original content file suffix
+ORIGINAL_SUFFIX = '.orig'
 
 def check_at_repository_root():
     if not os.path.exists('.git'):
@@ -49,8 +51,8 @@ def remove_current_translations():
     '''
     for (_,name) in all_ts_files():
         os.remove(name)
-    for (_,name) in all_ts_files('.orig'):
-        os.remove(name + '.orig')
+    for (_,name) in all_ts_files(suffix=ORIGINAL_SUFFIX):
+        os.remove(name + ORIGINAL_SUFFIX)
 
 def fetch_all_translations():
     if subprocess.call([TX, 'pull', '-f', '-a']):
@@ -186,12 +188,12 @@ def postprocess_translations(reduce_diff_hacks=False):
         ET._escape_cdata = escape_cdata
 
     for (filename,filepath) in all_ts_files():
-        os.rename(filepath, filepath+'.orig')
+        os.rename(filepath, filepath + ORIGINAL_SUFFIX)
 
-    for (filename,filepath) in all_ts_files('.orig'):
+    for (filename,filepath) in all_ts_files(suffix=ORIGINAL_SUFFIX):
         # pre-fixups to cope with transifex output
         parser = ET.XMLParser(encoding='utf-8') # need to override encoding because 'utf8' is not understood only 'utf-8'
-        with open(filepath + '.orig', 'rb') as f:
+        with open(filepath + ORIGINAL_SUFFIX, 'rb') as f:
             data = f.read()
         # remove control characters; this must be done over the entire file otherwise the XML parser will fail
         data = remove_invalid_characters(data)


### PR DESCRIPTION
It appears that conversion from XLIFF format to Qt's TS is not enough for correct update translation files in the main repo.

The problem is that the `approved` attributes of the `<trans-unit>` tags of XLIFF translation files fetched from Transifex do not follow the actual status of a messages: neither "translated:yes/no", nor "reviewed:yes/no".

Every new translatable message in the code, after `make translate` ends in the `bitcoin_en.ts` with an empty element
```
<translation type="unfinished"></translation>
```
and in  the `bitcoin_en.xlf` without `approved="yes"`.

And those attributes--`type="unfinished"` and absence of `approved="yes"`--are inherited by the fetched XLIFF translation files and the converted TS files.

Ignoring the `type="unfinished"` attribute seems the easiest way to cope with this issue.