### PR TITLE
backport.py expects pulls that are prefixed with repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ backport
 --------
 
 Script to backport pull requests in order of merge, to minimize number of conflicts.
-Pull ids are listed in `to_backport.txt` or given on the command line.
+Pull ids are listed in `to_backport.txt` or given on the command line, and they must be prefixed
+with the repository name, e.g.:
+
+```bash
+../bitcoin-maintainer-tools/backport.py bitcoin/bitcoin#21907 bitcoin-core/gui#277 bitcoin-core/gui#365
+
+```
 
 Requires `pip3 install gitpython` or similar.
 

--- a/backport.py
+++ b/backport.py
@@ -22,9 +22,9 @@ def ask_prompt(text):
     print("",file=sys.stderr)
     return reply
 
-merge_re = re.compile('^Merge (#[0-9]+)')
+merge_re = re.compile('^Merge (\w+(?:-\w+)*/\w+(?:-\w+)*#[0-9]+)')
 if len(sys.argv) > 1:
-    pulls = ['#'+x.strip() for x in sys.argv[1:]]
+    pulls = [x.strip() for x in sys.argv[1:]]
 else:
     with open('to_backport.txt','r') as f:
         pulls = [x.strip() for x in f if x.strip()]


### PR DESCRIPTION
It is required because since #92 merge commit messages always include `repo_from`.

Example of usage: https://github.com/bitcoin/bitcoin/pull/22427.