### PR TITLE
Use body as empty string when GitHub API responds with None

### DIFF
--- a/github-merge.py
+++ b/github-merge.py
@@ -81,6 +81,8 @@ def sanitize_ghdata(rec):
     '''
     if 'title' in rec: # only for PRs
         rec['title'] = sanitize(rec['title'], newlines=False)
+    if rec['body'] is None:
+        rec['body'] = ''
     rec['body'] = sanitize(rec['body'], newlines=True)
 
     # "Github username may only contain alphanumeric characters or hyphens'.


### PR DESCRIPTION



If there is nothing in the body of a PR, GitHub API responds with `None`. Added an `if` statement to use body as empty string if response is `None`.

Fixes https://github.com/bitcoin-core/bitcoin-maintainer-tools/issues/111

Can test this by creating a PR in some repository with no body or use this PR: https://github.com/prayank23/bitcoin/pull/6



<details>
  <summary>Python code to test</summary>
  
```python
import codecs
import unicodedata
import re
import json
from urllib.request import Request, urlopen

def get_response(req_url, ghtoken):
    req = Request(req_url)
    if ghtoken is not None:
        req.add_header('Authorization', 'token ' + ghtoken)
    return urlopen(req)

def sanitize(s, newlines=False):

    return ''.join(ch for ch in s if unicodedata.category(ch)[0] != "C" or (ch == '\n' and newlines))


def sanitize_ghdata(rec):

    if 'title' in rec:
        rec['title'] = sanitize(rec['title'], newlines=False)
    if rec['body'] is None:
        rec['body'] = ''
    rec['body'] = sanitize(rec['body'], newlines=True)

    if not re.match('[a-zA-Z0-9-]+\Z', rec['user']['login'], re.DOTALL):
        raise ValueError('Github username contains invalid characters: {}'.format(sanitize(rec['user']['login'])))

    return rec

def main():
    reader = codecs.getreader('utf-8')
    req_url = "https://api.github.com/repos/prayank23/bitcoin/pulls/6"
    ghtoken = "YOURGITHUBTOKEN"

    response = sanitize_ghdata(json.load(reader(get_response(req_url, ghtoken))))
    print(response)

if __name__ == '__main__':
    main()
```

</details>