### PR TITLE
document post-process action of dropping untranslated languages

### DIFF
--- a/update-translations.py
+++ b/update-translations.py
@@ -12,6 +12,7 @@ It will do the following automatically:
 - post-process them into valid and committable format
   - remove invalid control characters
   - remove location tags (makes diffs less noisy)
+  - drop untranslated languages
 - update git for added translations
 - update build system
 '''


### PR DESCRIPTION
We began of policy of dropping languages which are mostly untranslated. The PR that introduced this policy did not document this post-process action. This documents this policy in the section of the update-translations.py script where we state the post-processing steps that we perform.

As such, this is a follow-up to #102 