### PR TITLE
Use new Transifex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ It will do the following automatically:
 - Post-process them into valid and committable format
 - Add missing translations to the build system (TODO)
 
+To be able to pull translation files from the Transifex website, it needs
+the [Transifex CLI](https://github.com/transifex/cli).
+
 clang-format
 ------------
 

--- a/update-translations.py
+++ b/update-translations.py
@@ -62,7 +62,7 @@ def remove_current_translations():
         os.remove(name + ORIGINAL_SUFFIX)
 
 def fetch_all_translations():
-    if subprocess.call([TX, 'pull', '-f', '-a']):
+    if subprocess.call([TX, 'pull', '--translations', '--force', '--all']):
         print('Error while fetching translations', file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
The old Transifex Command-Line Tool is considered deprecated (as of January 2022) and will sunset on Nov 30, 2022.

See: https://github.com/transifex/transifex-client/pull/340

A PR with accompanying changes to `.tx/config`: bitcoin/bitcoin#26321