### PR TITLE
fastcopy-chaindata: Leveldb file numbers can exceed 6 digits

### DIFF
--- a/fastcopy-chaindata.py
+++ b/fastcopy-chaindata.py
@@ -47,7 +47,7 @@ def link_leveldb(src: str, dst: str):
     ldb_files = []
     other_files = []
     for fname in os.listdir(src):
-        if re.match('^[0-9]{6}.ldb$', fname):
+        if re.match('^[0-9]{6,}.ldb$', fname):
             ldb_files.append(fname)
         else:
             other_files.append(fname)


### PR DESCRIPTION
For long-running instances, leveldb file numbers can go on beyond 6 digits. Adapt the regexp to this.