### PR TITLE
check service flags being supported by  dns providers

### DIFF
--- a/check-dnsseeds.py
+++ b/check-dnsseeds.py
@@ -3,7 +3,18 @@
 Simple script to check the status of all Bitcoin Core DNS seeds.
 Seeds are available from https://github.com/bitcoin/bitcoin/blob/master/src/kernel/chainparams.cpp
 '''
+import argparse
 import subprocess
+from itertools import combinations
+
+NODE_NONE = 0
+NODE_NETWORK = (1 << 0)
+NODE_BLOOM = (1 << 2)
+NODE_WITNESS = (1 << 3)
+NODE_COMPACT_FILTERS = (1 << 6)
+NODE_NETWORK_LIMITED = (1 << 10)
+NODE_P2P_V2 = (1 << 11)
+
 
 SEEDS_PER_NETWORK={
     'mainnet': [
@@ -43,7 +54,42 @@ def check_seed(x):
     else:
         print(f"\x1b[91mFAIL\x1b[0m {x}")
 
-if __name__ == '__main__':
+def get_combinations(services):
+   
+    all_flags = services.values()
+    all_combinations = []
+
+    for i in range(1, len(all_flags) + 1):
+        for combo in combinations(all_flags, i):
+            combination_value = sum(combo)
+            combination_hex = hex(combination_value)[2:].upper()
+            combination_names = [service for service, flag in services.items() if flag in combo]
+            all_combinations.append((combination_hex, combination_names))
+  
+    return all_combinations
+
+def check_dns_support(combination_hex, provider):
+    """
+    Checks if a DNS provider supports a given combination of service flags.
+    """
+    
+    domain = f"x{combination_hex}.{provider}"
+    command = ["dig", domain]
+    try:
+        result = subprocess.run(command, capture_output=True, check=True)
+        output = result.stdout.decode("utf-8")
+        return "ANSWER SECTION" in output
+    except subprocess.CalledProcessError:
+        return False  
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Bitcoin Core Filter DNS Seeds')
+    parser.add_argument('--filter-services', action='store_true', help='Scan which filters are in use')
+    args = parser.parse_args()
+
+
+    print("\nBitcoin Core DNS Seed Status Check:\n")
+
     for (network, seeds) in SEEDS_PER_NETWORK.items():
         print(f"\x1b[90m* \x1b[97m{network}\x1b[0m")
 
@@ -51,3 +97,26 @@ if __name__ == '__main__':
             check_seed(hostname)
 
         print()
+
+    print("\n")
+
+    if args.filter_services:
+        combinations = get_combinations({
+            "NODE_NONE": NODE_NONE,
+            "NODE_NETWORK": NODE_NETWORK,
+            "NODE_BLOOM": NODE_BLOOM,
+            "NODE_WITNESS": NODE_WITNESS,
+            "NODE_COMPACT_FILTERS": NODE_COMPACT_FILTERS,
+            "NODE_NETWORK_LIMITED": NODE_NETWORK_LIMITED,
+            "NODE_P2P_V2": NODE_P2P_V2,
+        })
+
+        print("All possible combinations of node services and their bit flags in hexadecimal:")
+        for combination_hex, service_names in combinations:
+            print(f"  Bit flag (hex): {combination_hex} - Service: {', '.join(service_names)}")
+
+            for (network, seeds) in SEEDS_PER_NETWORK.items():
+                for hostname in seeds:
+                    supports_combination = check_dns_support(combination_hex, hostname)
+                    print(f" Network: {network}, Provider: {hostname} - Supports Service: {supports_combination}")
+


### PR DESCRIPTION

Currently,  [comments](https://github.com/bitcoin/bitcoin/blob/c05c214f2e9cfd6070a3c7680bfa09358fd9d97a/src/kernel/chainparams.cpp#L137) for DNS seed filtering are not updated, as discussed [here](https://github.com/bitcoin/bitcoin/issues/29911) and [here](https://github.com/bitcoin/bitcoin/pull/29809). Opening a pull request to update the comments can be noisy. Therefore, I have modified this script to generate all possible combinations of  service flags along with their corresponding hexadecimal values and include a function to check if a DNS provider supports a given combination of node services.
My proposal is to add a [comment](https://github.com/bitcoin/bitcoin/blob/c05c214f2e9cfd6070a3c7680bfa09358fd9d97a/src/kernel/chainparams.cpp#L137) referencing this script to ensure all filters are obtained