### PR TITLE
Remove unused imports

### DIFF
--- a/list-pulls.py
+++ b/list-pulls.py
@@ -21,11 +21,11 @@ likely needs to be extensively manually edited before ending up in the release
 notes.
 '''
 # W.J. van der Laan 2017-2021
+# The Bitcoin Core developers 2017-2021, 2025
 # SPDX-License-Identifier: MIT
 import subprocess
 import re
 import json
-import time
 import sys, os
 from collections import namedtuple, defaultdict
 
@@ -463,4 +463,3 @@ data_out = {
 with open('pulls.json','w') as f:
     json.dump(data_out, f, sort_keys=True,
                            indent=4, separators=(',', ': '))
-

--- a/termlib/attr.py
+++ b/termlib/attr.py
@@ -1,26 +1,31 @@
 class Attr:
-    '''
+    """
     Terminal output attributes.
-    '''
+    """
+    @staticmethod
     def fg(r, g, b):
         return f'\x1b[38;2;{r};{g};{b}m'
 
+    @staticmethod
     def bg(r, g, b):
         return f'\x1b[48;2;{r};{g};{b}m'
 
+    @staticmethod
     def fg_hex(color):
         if color[0] == '#':
             color = color[1:]
-        assert(len(color) == 6)
+        assert len(color) == 6
         return Attr.fg(int(color[0:2], 16), int(color[2:4], 16), int(color[4:6], 16))
 
+    @staticmethod
     def bg_hex(color):
         if color[0] == '#':
             color = color[1:]
-        assert(len(color) == 6)
+        assert len(color) == 6
         return Attr.bg(int(color[0:2], 16), int(color[2:4], 16), int(color[4:6], 16))
 
-    def close(attr):
+    @staticmethod
+    def close():
         # Close an attribute (restore terminal to "neutral")
         return Attr.RESET
 

--- a/termlib/tableprinter.py
+++ b/termlib/tableprinter.py
@@ -65,7 +65,11 @@ class TablePrinter:
         self.columns = columns
 
     def format_row(self, rec):
-        return ' '.join((entry[0] + pad(str(entry[1]), col.width, col.align) + self.attr.close(entry[0]) for entry, col in zip(rec, self.columns)))
+        return ' '.join(
+            (entry[0] +
+             pad(str(entry[1]), col.width, col.align) +
+             self.attr.close()
+             for entry, col in zip(rec, self.columns)))
 
     def print_row(self, rec):
         self.out.write(f'{self.format_row(rec)}\n')

--- a/treehash512.py
+++ b/treehash512.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017 The Bitcoin Core developers
+# Copyright (c) 2017, 2025 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 '''
@@ -11,9 +11,7 @@ Usage:
     treehash512.py [<commithash>]
 '''
 import os
-from sys import stdin,stdout,stderr
 import sys
-import argparse
 import hashlib
 import subprocess
 
@@ -78,4 +76,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
.gitignore: Ignore PyCharm metadata.
clang-format.py: Python 3.
list-pulls.py: Remove unused import.
termlib/attr.py: Explicit class methods.
termlib/tableprinter.py: Adapts signature change.
treehash512.py: Remove unused imports.
