### PR TITLE
backport: Allow backporting from branches other than master

### DIFF
--- a/backport.py
+++ b/backport.py
@@ -14,6 +14,7 @@ GIT = os.getenv('GIT','git')
 BASH = os.getenv('BASH','bash')
 # Other configuration
 SRCREPO = os.getenv('SRCREPO', '../bitcoin')
+BRANCH = os.getenv('BRANCH', 'master')
 
 def ask_prompt(text):
     print(text,end=" ",file=sys.stderr)
@@ -33,7 +34,7 @@ execute = True
 
 pulls = set(pulls)
 repo = git.Repo(SRCREPO)
-head = repo.heads['master']
+head = repo.heads[BRANCH]
 
 commit = head.commit
 to_backport = []


### PR DESCRIPTION
Some repos merge into branches not named `master` (e.g. `main`) and we should be able to make backports from them.