### PR TITLE
Update `update-translations.py`

### DIFF
--- a/update-translations.py
+++ b/update-translations.py
@@ -280,12 +280,6 @@ def update_build_systems():
         f.write('    </qresource>\n')
         f.write('</RCC>\n')
 
-    # update Makefile include
-    with open('src/Makefile.qt_locale.include', 'w') as f:
-        f.write('QT_TS = \\\n')
-        f.write(' \\\n'.join(f'  qt/locale/{filename}' for (filename, basename, lang) in filename_lang))
-        f.write('\n') # make sure last line doesn't end with a backslash
-
     # Generate ts_files.cmake with an explicit list of .ts files in src/qt/locale
     with open(f'{LOCALE_DIR}/ts_files.cmake', 'w') as f:
         f.write('set(ts_files\n')

--- a/update-translations.py
+++ b/update-translations.py
@@ -24,7 +24,7 @@ import io
 import xml.etree.ElementTree as ET
 
 # Name of Qt lconvert tool
-LCONVERT = 'lconvert'
+LCONVERT = os.getenv('LCONVERT', '/usr/lib/qt6/bin/lconvert')
 # Name of transifex tool
 TX = os.getenv('TX', 'tx')
 # Name of source language file without extension


### PR DESCRIPTION
1. On most systems, the `lconvert` binary available in the `$PATH` (if any) belongs to Qt 5. This change requires setting the `LCONVERT` environment variable explicitly to ensure that the Qt 6 binary is used instead.

2. The last Bitcoin Core version that uses the Autotools-based build system (28.x) is reaching EOL soon, making it highly unlikely there will ever be a need to update translations for it. So removing the outdated code.