### PR TITLE
github-merge: Allow using git submodules

### DIFF
--- a/github-merge.py
+++ b/github-merge.py
@@ -163,6 +163,8 @@ def tree_sha512sum(commit='HEAD'):
     for line in subprocess.check_output([GIT, 'ls-tree', '--full-tree', '-r', commit]).splitlines():
         name_sep = line.index(b'\t')
         metadata = line[:name_sep].split() # perms, 'blob', blobid
+        if metadata[1] == b'commit':
+            continue
         assert(metadata[1] == b'blob')
         name = line[name_sep+1:]
         files.append(name)


### PR DESCRIPTION
This PR adds support for merging repositories that use a git submodule on their default branch (such as https://github.com/bitcoin-core/gui-qml).

Without this change, the the following error occurs:
```
Traceback (most recent call last):
  File "/home/hebasto/dev/bitcoin-qml/../bitcoin-maintainer-tools/github-merge.py", line 498, in <module>
    main()
    ~~~~^^
  File "/home/hebasto/dev/bitcoin-qml/../bitcoin-maintainer-tools/github-merge.py", line 402, in main
    first_sha512 = tree_sha512sum()
  File "/home/hebasto/dev/bitcoin-qml/../bitcoin-maintainer-tools/github-merge.py", line 166, in tree_sha512sum
    assert(metadata[1] == b'blob')
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```